### PR TITLE
The comma separator breaks the date values

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var serialize = function(name, val, opt){
 /// @return {Object}
 var parse = function(str) {
     var obj = {}
-    var pairs = str.split(/[;,] */);
+    var pairs = str.split(/[;] */);
 
     pairs.forEach(function(pair) {
         var eq_idx = pair.indexOf('=')


### PR DESCRIPTION
Hi,

Per RFC, the date value of the Expires value is something like: `Wed, 09 Jun 2021 10:18:14 GMT`. However, the current expression breaks the parsing:

``` bash
node
> var cookie = require('cookie')
> console.log(cookie.parse('lang=en-US; Expires=Wed, 09 Jun 2021 10:18:14 GMT'))
{ lang: 'en-US', Expires: 'Wed', '': '09 Jun 2021 10:18:14 GMT' }
#                                ^^^ OOPSIE
```

After the removal of the comma, it looks better:

``` bash
> console.log(cookie.parse('lang=en-US; Expires=Wed, 09 Jun 2021 10:18:14 GMT'))
{ lang: 'en-US', Expires: 'Wed, 09 Jun 2021 10:18:14 GMT' }
```

The example was taken from the RFC itself (6265, [Section 3.1](http://tools.ietf.org/html/rfc6265#section-3.1)).

No unit test was harmed in the making of this fix.
