### PR TITLE
Ignore escape error and return original value better than throw the error

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,11 @@ var parse = function(str) {
 
         // only assign once
         if (undefined == obj[key]) {
-            obj[key] = decode(val);
+            try {
+                obj[key] = decode(val);
+            } catch (e) {
+                obj[key] = val;
+            }
         }
     });
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -23,3 +23,6 @@ test('escaping', function() {
             cookie.parse('email=%20%22%2c%3b%2f'));
 });
 
+test('ignore escaping error and return original value', function() {
+    assert.deepEqual({ foo: '%1', bar: 'bar' }, cookie.parse('foo=%1;bar=bar'));
+});


### PR DESCRIPTION
I don't agree throw 400 response when cookie parse error.

Most normal user don't know how to clean up the browser cookies. 

If their cookies was modified by accident, they will always got the 400 response.

I think return the original value is better than throw the escape error.

cc @visionmedia
