### PR TITLE
add cookie limit for parse !

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ var hdr = cookie.serialize('foo', 'bar');
 
 var cookies = cookie.parse('foo=bar; cat=meow; dog=ruff');
 // cookies = { foo: 'bar', cat: 'meow', dog: 'ruff' };
+
+var cookies = cookie.parse('foo=bar; cat=meow; dog=ruff', 2);
+// cookies = { foo: 'bar', cat: 'meow'};
 ```
 
 ## more

--- a/index.js
+++ b/index.js
@@ -26,10 +26,11 @@ var serialize = function(name, val, opt){
 /// Parse the given cookie header string into an object
 /// The object has the various cookies as keys(names) => values
 /// @param {String} str
+//  @param {Number} limit ,the max cookie pair to parse
 /// @return {Object}
-var parse = function(str) {
-    var obj = {}
-    var pairs = str.split(/[;,] */);
+var parse = function(str, limit) {
+    var obj = {};
+    var pairs = str.split(/[;,] */, limit ? limit : maxCookies);
 
     pairs.forEach(function(pair) {
         var eq_idx = pair.indexOf('=')
@@ -57,5 +58,11 @@ var parse = function(str) {
 var encode = encodeURIComponent;
 var decode = decodeURIComponent;
 
+var maxCookies = 1000;
+var setMaxCookies = function (n) {
+  maxCookies = n;
+};
+
 module.exports.serialize = serialize;
 module.exports.parse = parse;
+module.exports.setMaxCookies = setMaxCookies;

--- a/test/parse.js
+++ b/test/parse.js
@@ -23,6 +23,11 @@ test('escaping', function() {
             cookie.parse('email=%20%22%2c%3b%2f'));
 });
 
+test('parse limit', function() {
+    assert.deepEqual({ bar: '123456789' },
+            cookie.parse('bar=123456789; name=Magic+Mouse', 1));
+});
+
 test('ignore escaping error and return original value', function() {
     assert.deepEqual({ foo: '%1', bar: 'bar' }, cookie.parse('foo=%1;bar=bar'));
 });


### PR DESCRIPTION
last year， someone find the DDos 

```
http://www.ocert.org/advisories/ocert-2011-003.html
```

now ， Node.js have fix the problem by adding limit for queryString parser, default 1000

as one of the input  of server, cookie parse has the same problem, so i add an limit for parse()

```
cookie.parse(cookiestr, limit);   // limit default equal 1000
```
