### PR TITLE
to accept cookies starts with a '.'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /// Serialize the a name value pair into a cookie string suitable for
 /// http headers. An optional options object specified cookie parameters
 ///
@@ -44,6 +43,7 @@ var parse = function(str) {
         // only assign once
         if (undefined == obj[key]) {
             try {
+                if (key[0] == ".")key = key.substr(1);
                 obj[key] = decode(val);
             } catch (e) {
                 obj[key] = val;


### PR DESCRIPTION
Cookies starts with a '.' will be ignored before.
Like ".aspxauth",the asp.net's authentication cookie.
Now it will change '.xxxx' to 'xxxx';
