### PR TITLE
Avoid throwing an exception when passed null or undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var serialize = function(name, val, opt){
 var parse = function(str, opt) {
     opt = opt || {};
     var obj = {}
-    var pairs = str.split(/; */);
+    var pairs = (str || "").split(/; */);
     var dec = opt.decode || decode;
 
     pairs.forEach(function(pair) {


### PR DESCRIPTION
Currently, the `parse` function throws an exception if `str` isn't a string, e.g. if it's not defined. It is entirely possible for `headers.cookie` to be undefined on an incoming HTTP request, but it seems reasonable to still execute `cookie.parse(request.headers.cookie)`. This PR makes the module respond gracefully.
