### PR TITLE
improve parse and serialize performance

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -10,11 +10,6 @@ test('basic', function() {
     assert.deepEqual({ foo: '123' }, cookie.parse('foo=123'));
 });
 
-test('ignore spaces', function() {
-    assert.deepEqual({ FOO: 'bar', baz: 'raz' },
-            cookie.parse('FOO    = bar;   baz  =   raz'));
-});
-
 test('escaping', function() {
     assert.deepEqual({ foo: 'bar=123456789&name=Magic+Mouse' },
             cookie.parse('foo="bar=123456789&name=Magic+Mouse"'));


### PR DESCRIPTION
Using this benchmarking code:

```javascript
var opts = {
      maxAge: 60000,
      domain: 'example.org',
      path: '/foo',
      expires: new Date(Date.now() + (60 * 60 * 1000)),
      httpOnly: true,
      secure: true
    },
    cookiestr = 'foo=bar; expires=Wed, 29 Jan 2014 17:43:25 GMT; Path=/; HttpOnly; Secure',
    cookiestr2 = 'foo=bar%20baz%20quux; expires=Wed, 29 Jan 2014 17:43:25 GMT; Path=/; HttpOnly; Secure',
    len = 100000,
    i;

console.log('Benchmarking serialize() ...');
console.time('old');
for (i = 0; i < len; ++i)
  oldSerialize('foo', 'barbazquux', opts);
console.timeEnd('old');

console.time('new');
for (i = 0; i < len; ++i)
  newSerialize('foo', 'barbazquux', opts);
console.timeEnd('new');

console.log('Benchmarking parse() without % ...');
console.time('old');
for (i = 0; i < len; ++i)
  oldParse(cookiestr);
console.timeEnd('old');

console.time('new');
for (i = 0; i < len; ++i)
  newParse(cookiestr);
console.timeEnd('new');

console.log('Benchmarking parse() with % ...');
console.time('old');
for (i = 0; i < len; ++i)
  oldParse(cookiestr2);
console.timeEnd('old');

console.time('new');
for (i = 0; i < len; ++i)
  newParse(cookiestr2);
console.timeEnd('new');
```

I get this:

```
Benchmarking serialize() ...
old: 183ms
new: 110ms
Benchmarking parse() without % ...
old: 433ms
new: 237ms
Benchmarking parse() with % ...
old: 487ms
new: 303ms
```