### PR TITLE
Adding more type safety checking an general code and jsdoc cleanup

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -53,4 +53,13 @@ test('dates', function() {
             cookie.parse('priority=true; expires=Wed, 29 Jan 2014 17:43:25 GMT; Path=/',{
                 decode: function(value) { return value; }
             }));
-})
+});
+
+test('assign only once', function() {
+  assert.deepEqual({ foo: '%1', bar: 'bar' },
+    cookie.parse('foo=%1;bar=bar;foo=boo;HttpOnly;Secure'));
+  assert.deepEqual({ foo: 'false', bar: 'bar' },
+    cookie.parse('foo=false;bar=bar;foo=true;HttpOnly;Secure'));
+  assert.deepEqual({ foo: '', bar: 'bar' },
+    cookie.parse('foo=;bar=bar;foo=boo;HttpOnly;Secure'));
+});

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -5,6 +5,12 @@ var cookie = require('..');
 
 suite('serialize');
 
+test('argument validation', function() {
+    assert.throws(cookie.serialize.bind(), /argument name must be a string/);
+    assert.throws(cookie.serialize.bind(null, 42), /argument name must be a string/);
+    assert.throws(cookie.serialize.bind(null, 'foo', 42), /argument val must be a string/);
+});
+
 test('basic', function() {
     assert.equal('foo=bar', cookie.serialize('foo', 'bar'));
     assert.equal('foo=bar%20baz', cookie.serialize('foo', 'bar baz'));
@@ -14,6 +20,22 @@ test('path', function() {
     assert.equal('foo=bar; Path=/', cookie.serialize('foo', 'bar', {
         path: '/'
     }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: 200
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: null
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: undefined
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: { path: '/foo/bar' }
+    }));
 });
 
 test('secure', function() {
@@ -21,8 +43,16 @@ test('secure', function() {
         secure: true
     }));
 
+    assert.equal('foo=bar; Secure', cookie.serialize('foo', 'bar', {
+        secure: 'true'
+    }));
+
     assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
         secure: false
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        secure: undefined
     }));
 });
 
@@ -30,11 +60,57 @@ test('domain', function() {
     assert.equal('foo=bar; Domain=example.com', cookie.serialize('foo', 'bar', {
         domain: 'example.com'
     }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: 200
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: null
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: undefined
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: { domain: 'foo.bar' }
+    }));
+});
+
+test('expires', function() {
+    assert.equal('foo=bar; Expires=' + (new Date()).toUTCString(), cookie.serialize('foo', 'bar', {
+        expires: (new Date()).toUTCString()
+    }));
+
+    assert.equal('foo=bar; Expires=' + (new Date()).toUTCString(), cookie.serialize('foo', 'bar', {
+        expires: new Date()
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        expires: 'not a date'
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        expires: { objectButNotDate: true }
+    }));
 });
 
 test('httpOnly', function() {
     assert.equal('foo=bar; HttpOnly', cookie.serialize('foo', 'bar', {
         httpOnly: true
+    }));
+
+    assert.equal('foo=bar; HttpOnly', cookie.serialize('foo', 'bar', {
+        httpOnly: 'true'
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        httpOnly: false
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        httpOnly: undefined
     }));
 });
 
@@ -43,8 +119,28 @@ test('maxAge', function() {
         maxAge: 1000
     }));
 
+    assert.equal('foo=bar; Max-Age=1000', cookie.serialize('foo', 'bar', {
+        maxAge: '1000'
+    }));
+
     assert.equal('foo=bar; Max-Age=0', cookie.serialize('foo', 'bar', {
         maxAge: 0
+    }));
+
+    assert.equal('foo=bar; Max-Age=0', cookie.serialize('foo', 'bar', {
+        maxAge: '0'
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        maxAge: null
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        maxAge: undefined
+    }));
+
+    assert.equal('foo=bar; Max-Age=3', cookie.serialize('foo', 'bar', {
+        maxAge: 3.14
     }));
 });
 
@@ -65,4 +161,4 @@ test('unencoded', function() {
     assert.deepEqual('cat=+ ', cookie.serialize('cat', '+ ', {
         encode: function(value) { return value; }
     }));
-})
+});


### PR DESCRIPTION
* Some general cleanup (missing semi-colons, jsdoc return and param type inaccuracies, etc.). 
* Applied string param checking to `.serialize()` as was most recently added to `.parse()`. 
* Added more type safety checking against expected params inside the `options` param object.
* Made the maxAge validation more compact and protect against floating point numbers
* Modified `.parse()` to check for own property rather than check falsy when checking whether the params object already had a value set