### PR TITLE
General cleanup of jsdoc, adding missing semi-colons and unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var encode = encodeURIComponent;
  *
  * @param {string} str
  * @param {object} [options]
- * @return {string}
+ * @return {object}
  * @public
  */
 
@@ -37,20 +37,20 @@ function parse(str, options) {
     throw new TypeError('argument str must be a string');
   }
 
-  var obj = {}
+  var obj = {};
   var opt = options || {};
   var pairs = str.split(/; */);
   var dec = opt.decode || decode;
 
   pairs.forEach(function(pair) {
-    var eq_idx = pair.indexOf('=')
+    var eq_idx = pair.indexOf('=');
 
     // skip things that don't look like key=value
     if (eq_idx < 0) {
       return;
     }
 
-    var key = pair.substr(0, eq_idx).trim()
+    var key = pair.substr(0, eq_idx).trim();
     var val = pair.substr(++eq_idx, pair.length).trim();
 
     // quoted values

--- a/test/parse.js
+++ b/test/parse.js
@@ -53,4 +53,13 @@ test('dates', function() {
             cookie.parse('priority=true; expires=Wed, 29 Jan 2014 17:43:25 GMT; Path=/',{
                 decode: function(value) { return value; }
             }));
-})
+});
+
+test('assign only once', function() {
+    assert.deepEqual({ foo: '%1', bar: 'bar' },
+        cookie.parse('foo=%1;bar=bar;foo=boo'));
+    assert.deepEqual({ foo: 'false', bar: 'bar' },
+        cookie.parse('foo=false;bar=bar;foo=true'));
+    assert.deepEqual({ foo: '', bar: 'bar' },
+        cookie.parse('foo=;bar=bar;foo=boo'));
+});

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -65,4 +65,4 @@ test('unencoded', function() {
     assert.deepEqual('cat=+ ', cookie.serialize('cat', '+ ', {
         encode: function(value) { return value; }
     }));
-})
+});


### PR DESCRIPTION
Some general cleanup (missing semi-colons, jsdoc return and param type inaccuracies) and added more test coverage.