### PR TITLE
Slight improvements to options object member validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,9 @@ function parse(str, options) {
   }
 
   var obj = {}
-  var opt = options || {};
+  var opt = typeof options === 'object' ? options : {};
   var pairs = str.split(/; */);
-  var dec = opt.decode || decode;
+  var dec = typeof opt.decode !== 'undefined' ? opt.decode : decode;
 
   pairs.forEach(function(pair) {
     var eq_idx = pair.indexOf('=')
@@ -84,8 +84,11 @@ function parse(str, options) {
  */
 
 function serialize(name, val, options) {
-  var opt = options || {};
-  var enc = opt.encode || encode;
+  var opt = typeof options === 'object' ? options : {};
+  var enc = typeof opt.encode !== 'undefined' ? opt.encode : encode;
+  if (typeof enc !== 'function') {
+    throw new TypeError('encode option must be a function');
+  }
   var pairs = [name + '=' + enc(val)];
 
   if (null != opt.maxAge) {
@@ -94,9 +97,10 @@ function serialize(name, val, options) {
     pairs.push('Max-Age=' + maxAge);
   }
 
-  if (opt.domain) pairs.push('Domain=' + opt.domain);
-  if (opt.path) pairs.push('Path=' + opt.path);
-  if (opt.expires) pairs.push('Expires=' + opt.expires.toUTCString());
+  if (typeof opt.domain === 'string') pairs.push('Domain=' + opt.domain);
+  if (typeof opt.path === 'string') pairs.push('Path=' + opt.path);
+  if (Date.parse(opt.expires)) pairs.push('Expires=' +
+    (new Date(opt.expires)).toUTCString());
   if (opt.httpOnly) pairs.push('HttpOnly');
   if (opt.secure) pairs.push('Secure');
 

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -14,6 +14,22 @@ test('path', function() {
     assert.equal('foo=bar; Path=/', cookie.serialize('foo', 'bar', {
         path: '/'
     }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: 200
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: null
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: undefined
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        path: { path: '/foo/bar' }
+    }));
 });
 
 test('secure', function() {
@@ -21,8 +37,16 @@ test('secure', function() {
         secure: true
     }));
 
+    assert.equal('foo=bar; Secure', cookie.serialize('foo', 'bar', {
+        secure: 'true'
+    }));
+
     assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
         secure: false
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        secure: undefined
     }));
 });
 
@@ -30,11 +54,57 @@ test('domain', function() {
     assert.equal('foo=bar; Domain=example.com', cookie.serialize('foo', 'bar', {
         domain: 'example.com'
     }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: 200
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: null
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: undefined
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        domain: { domain: 'foo.bar' }
+    }));
+});
+
+test('expires', function() {
+    assert.equal('foo=bar; Expires=' + (new Date()).toUTCString(), cookie.serialize('foo', 'bar', {
+        expires: (new Date()).toUTCString()
+    }));
+
+    assert.equal('foo=bar; Expires=' + (new Date()).toUTCString(), cookie.serialize('foo', 'bar', {
+        expires: new Date()
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        expires: 'not a date'
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        expires: { objectButNotDate: true }
+    }));
 });
 
 test('httpOnly', function() {
     assert.equal('foo=bar; HttpOnly', cookie.serialize('foo', 'bar', {
         httpOnly: true
+    }));
+
+    assert.equal('foo=bar; HttpOnly', cookie.serialize('foo', 'bar', {
+        httpOnly: 'true'
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        httpOnly: false
+    }));
+
+    assert.equal('foo=bar', cookie.serialize('foo', 'bar', {
+        httpOnly: undefined
     }));
 });
 
@@ -59,6 +129,14 @@ test('parse->serialize', function() {
 
     assert.deepEqual({ cat: ' ";/' }, cookie.parse(
       cookie.serialize('cat', ' ";/')));
+});
+
+test('encoded method validation', function() {
+   assert.throws(cookie.serialize.bind(null, 'cat', ' ', {
+       encode: 42
+   }), /encode option must be a function/i);
+
+    assert.deepEqual('cat=%20', cookie.serialize('cat', ' ', {}));
 });
 
 test('unencoded', function() {


### PR DESCRIPTION
Explicitly checking for options object members expected data types (`typeof 'function'` for encode/decode, valid `Date` or date strings for `expiration`, valid `string` values for `domain` and `path`), also using shorthand for "if value is acceptable add to array" logic.