### PR TITLE
Update index.js, #serialize so it accepts opt.expires as a date strin…

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function serialize(name, val, options) {
 
   if (opt.domain) pairs.push('Domain=' + opt.domain);
   if (opt.path) pairs.push('Path=' + opt.path);
-  if (opt.expires) pairs.push('Expires=' + opt.expires.toUTCString());
+  if (opt.expires) pairs.push('Expires=' + new Date(opt.expires).toUTCString());
   if (opt.httpOnly) pairs.push('HttpOnly');
   if (opt.secure) pairs.push('Secure');
 


### PR DESCRIPTION
Update index.js, #serialize so it accepts opt.expires as a date string or a unix number

Recently removed the cookie parser middleware for express' own. The format is similar, the only difference is that `expires` it is not returned as a `Date` object, it is returned as a date string. 

Wrapping `opt.expires` with `new Date`, guarantees that calling the `toUTCString` method does not throw. This eases the transition from the other cookie middleware to this one.

	TypeError: undefined is not a function
	    at Object.serialize (/home/ascari/node_modules/express-session/node_modules/cookie/index.js:25:58)
	    at setcookie (/home/ascari/node_modules/express-session/index.js:577:21)
	    at ServerResponse.<anonymous> (/home/ascari/node_modules/express-session/index.js:200:7)
	    at ServerResponse.writeHead (/home/ascari/node_modules/express-session/node_modules/on-headers/index.js:44:16)
	    at ServerResponse._implicitHeader (_http_server.js:172:8)
	    at ServerResponse.OutgoingMessage.write (_http_outgoing.js:423:10)
	    at writetop (/home/ascari/node_modules/express-session/index.js:248:26)
	    ..etc