### PR TITLE
cookie.expires can be

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ var cookies = cookie.parse('foo=bar; cat=meow; dog=ruff');
 
 The serialize function takes a third parameter, an object, to set cookie options. See the RFC for valid values.
 
+`cookie.expires` can be a Date object, a unix timestamp or a date string in [ISO 8601 format](http://www.w3.org/TR/NOTE-datetime) or using the [RFC2822 / IETF date syntax (RFC2822 Section 3.3)](http://tools.ietf.org/html/rfc2822#page-14).
+
 ### path
 > cookie path
 

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function serialize(name, val, options) {
 
   if (opt.domain) pairs.push('Domain=' + opt.domain);
   if (opt.path) pairs.push('Path=' + opt.path);
-  if (opt.expires) pairs.push('Expires=' + opt.expires.toUTCString());
+  if (opt.expires) pairs.push('Expires=' + new Date(opt.expires).toUTCString());
   if (opt.httpOnly) pairs.push('HttpOnly');
   if (opt.secure) pairs.push('Secure');
 

--- a/index.js
+++ b/index.js
@@ -96,7 +96,9 @@ function serialize(name, val, options) {
 
   if (opt.domain) pairs.push('Domain=' + opt.domain);
   if (opt.path) pairs.push('Path=' + opt.path);
-  if (opt.expires) pairs.push('Expires=' + new Date(opt.expires).toUTCString());
+  var now = new Date(opt.expires);
+  var utc = new Date(now.getTime() + now.getTimezoneOffset() * 60 * 1000);
+  if (opt.expires) pairs.push('Expires=' + utc.toUTCString());
   if (opt.httpOnly) pairs.push('HttpOnly');
   if (opt.secure) pairs.push('Secure');
 

--- a/index.js
+++ b/index.js
@@ -98,10 +98,10 @@ function serialize(name, val, options) {
   if (opt.path) pairs.push('Path=' + opt.path);
   if (opt.expires) 
   {
-      var now = new Date(opt.expires);
-      if (now + '' === 'Invalid Date') throw new Error('expires should be a valid datestring, unix timestamp or Date object');
-      var utc = new Date(now.getTime() - now.getTimezoneOffset() * 60 * 1000);
-      pairs.push('Expires=' + utc.toUTCString());
+    var now = new Date(opt.expires);
+    if (now + '' === 'Invalid Date') throw new Error('expires should be a valid datestring, unix timestamp or Date object');
+    var utc = new Date(now.getTime() - now.getTimezoneOffset() * 60 * 1000);
+    pairs.push('Expires=' + utc.toUTCString());
   }
   if (opt.httpOnly) pairs.push('HttpOnly');
   if (opt.secure) pairs.push('Secure');

--- a/index.js
+++ b/index.js
@@ -96,9 +96,13 @@ function serialize(name, val, options) {
 
   if (opt.domain) pairs.push('Domain=' + opt.domain);
   if (opt.path) pairs.push('Path=' + opt.path);
-  var now = new Date(opt.expires);
-  var utc = new Date(now.getTime() + now.getTimezoneOffset() * 60 * 1000);
-  if (opt.expires) pairs.push('Expires=' + utc.toUTCString());
+  if (opt.expires) 
+  {
+      var now = new Date(opt.expires);
+      if (now + '' === 'Invalid Date') throw new Error('expires should be a valid datestring, unix timestamp or Date object');
+      var utc = new Date(now.getTime() - now.getTimezoneOffset() * 60 * 1000);
+      pairs.push('Expires=' + utc.toUTCString());
+  }
   if (opt.httpOnly) pairs.push('HttpOnly');
   if (opt.secure) pairs.push('Secure');
 

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -68,73 +68,82 @@ test('unencoded', function() {
 })
 
 test('opt.expires as Date', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: new Date('08 12 2015')
     }));
 })
 
 test('opt.expires as Unix Timestamp', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: +new Date('08 12 2015')
     }));
 })
 
 test('opt.expires as Date String (mm dd yyyy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '08 12 2015'
     }));
 })
 
 test('opt.expires as Date String (dd MMM yy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12 Aug 15'
     }));
 })
 
 test('opt.expires as Date String (dd-MMM-yy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12-Aug-15'
     }));
 })
 
 test('opt.expires as Date String (dd/MMM/yy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12-Aug-15'
     }));
 })
 
 test('opt.expires as Date String (RFC2822-formatted)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: 'Wed, 12 Aug 2015 05:00:00 EDT +0000'
     }));
 })
 
 test('opt.expires as Date String (RFC2822-formatted am/pm)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12 August, 2015 0:00:00 Am'
     }));
 })
 
 test('opt.expires as Datetime String (mm dd yyyy hh:mm:ss)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '08 12 2015 00:00:00'
     }));
 })
 
 test('opt.expires as Datetime String (MM dd, yyyy hh:mm:dd)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: 'August 12, 2015 00:00:00'
     }));
 })
 
 test('opt.expires as Datetime String (ISO)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '2015-08-12T05:00:00'
     }));
 })
 
 test('opt.expires as Datetime String (ISO w/milliseconds)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '2015-08-12T05:00:00.000Z'
     }));
+})
+
+test('opt.expires as foo', function() {
+    assert.throws(
+        function () {
+            cookie.serialize('foo', 'bar', {expires: 'foo'})
+        },
+        'expire should be a valid datestring, unix timestamp or Date object'
+    )
 })

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -105,7 +105,7 @@ test('opt.expires as Date String (dd/MMM/yy)', function() {
 
 test('opt.expires as Date String (RFC2822-formatted)', function() {
     assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
-        expires: 'Wed, 12 Aug 2015 05:00:00 EDT +0000'
+        expires: 'Wed, 12 Aug 2015 00:00:00 EDT +0000'
     }));
 })
 
@@ -129,13 +129,13 @@ test('opt.expires as Datetime String (MM dd, yyyy hh:mm:dd)', function() {
 
 test('opt.expires as Datetime String (ISO)', function() {
     assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
-        expires: '2015-08-12T05:00:00'
+        expires: '2015-08-12T00:00:00'
     }));
 })
 
 test('opt.expires as Datetime String (ISO w/milliseconds)', function() {
     assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 00:00:00 GMT', cookie.serialize('foo', 'bar', {
-        expires: '2015-08-12T05:00:00.000Z'
+        expires: '2015-08-12T00:00:00.000Z'
     }));
 })
 

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -66,3 +66,75 @@ test('unencoded', function() {
         encode: function(value) { return value; }
     }));
 })
+
+test('opt.expires as Date', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: new Date('08 12 2015')
+    }));
+})
+
+test('opt.expires as Unix Timestamp', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: +new Date('08 12 2015')
+    }));
+})
+
+test('opt.expires as Date String (mm dd yyyy)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '08 12 2015'
+    }));
+})
+
+test('opt.expires as Date String (dd MMM yy)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '12 Aug 15'
+    }));
+})
+
+test('opt.expires as Date String (dd-MMM-yy)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '12-Aug-15'
+    }));
+})
+
+test('opt.expires as Date String (dd/MMM/yy)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '12-Aug-15'
+    }));
+})
+
+test('opt.expires as Date String (RFC2822-formatted)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: 'Wed, 12 Aug 2015 05:00:00 EDT +0000'
+    }));
+})
+
+test('opt.expires as Date String (RFC2822-formatted am/pm)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '12 August, 2015 0:00:00 Am'
+    }));
+})
+
+test('opt.expires as Datetime String (mm dd yyyy hh:mm:ss)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '08 12 2015 00:00:00'
+    }));
+})
+
+test('opt.expires as Datetime String (MM dd, yyyy hh:mm:dd)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: 'August 12, 2015 00:00:00'
+    }));
+})
+
+test('opt.expires as Datetime String (ISO)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '2015-08-12T05:00:00'
+    }));
+})
+
+test('opt.expires as Datetime String (ISO w/milliseconds)', function() {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+        expires: '2015-08-12T05:00:00.000Z'
+    }));
+})

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -68,73 +68,73 @@ test('unencoded', function() {
 })
 
 test('opt.expires as Date', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: new Date('08 12 2015')
     }));
 })
 
 test('opt.expires as Unix Timestamp', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: +new Date('08 12 2015')
     }));
 })
 
 test('opt.expires as Date String (mm dd yyyy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '08 12 2015'
     }));
 })
 
 test('opt.expires as Date String (dd MMM yy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12 Aug 15'
     }));
 })
 
 test('opt.expires as Date String (dd-MMM-yy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12-Aug-15'
     }));
 })
 
 test('opt.expires as Date String (dd/MMM/yy)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12-Aug-15'
     }));
 })
 
 test('opt.expires as Date String (RFC2822-formatted)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: 'Wed, 12 Aug 2015 05:00:00 EDT +0000'
     }));
 })
 
 test('opt.expires as Date String (RFC2822-formatted am/pm)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '12 August, 2015 0:00:00 Am'
     }));
 })
 
 test('opt.expires as Datetime String (mm dd yyyy hh:mm:ss)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '08 12 2015 00:00:00'
     }));
 })
 
 test('opt.expires as Datetime String (MM dd, yyyy hh:mm:dd)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: 'August 12, 2015 00:00:00'
     }));
 })
 
 test('opt.expires as Datetime String (ISO)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '2015-08-12T05:00:00'
     }));
 })
 
 test('opt.expires as Datetime String (ISO w/milliseconds)', function() {
-    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 05:00:00 GMT', cookie.serialize('foo', 'bar', {
+    assert.deepEqual('foo=bar; Expires=Wed, 12 Aug 2015 10:00:00 GMT', cookie.serialize('foo', 'bar', {
         expires: '2015-08-12T05:00:00.000Z'
     }));
 })


### PR DESCRIPTION
* a Date object
* a unix timestamp
* a date string with ISO 8601 format
* a date string with RFC2822 / IETF date syntax