### PR TITLE
Parse Set-Cookie HttpOnly and Secure with boolean true value

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,30 +49,36 @@ function parse(str, options) {
     throw new TypeError('argument str must be a string');
   }
 
-  var obj = {}
+  var obj = {};
   var opt = options || {};
   var pairs = str.split(pairSplitRegExp);
   var dec = opt.decode || decode;
 
   pairs.forEach(function(pair) {
-    var eq_idx = pair.indexOf('=')
+    var eq_idx = pair.indexOf('=');
+    var key, val;
 
-    // skip things that don't look like key=value
-    if (eq_idx < 0) {
-      return;
+    // things like key=value
+    if (eq_idx >= 0) {
+      key = pair.substr(0, eq_idx).trim();
+      val = pair.substr(++eq_idx, pair.length).trim();
+
+      // quoted values
+      if ('"' == val[0]) {
+        val = val.slice(1, -1);
+      }
+
+      // only assign once
+      if (undefined == obj[key]) {
+        obj[key] = tryDecode(val, dec);
+      }
     }
-
-    var key = pair.substr(0, eq_idx).trim()
-    var val = pair.substr(++eq_idx, pair.length).trim();
-
-    // quoted values
-    if ('"' == val[0]) {
-      val = val.slice(1, -1);
-    }
-
-    // only assign once
-    if (undefined == obj[key]) {
-      obj[key] = tryDecode(val, dec);
+    // things with implicit boolean value like HttpOnly and Secure
+    else {
+      key = pair.trim();
+      if (key === 'HttpOnly' || key === 'Secure') {
+        obj[key] = true;
+      }
     }
   });
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -32,8 +32,12 @@ test('ignore escaping error and return original value', function() {
     assert.deepEqual({ foo: '%1', bar: 'bar' }, cookie.parse('foo=%1;bar=bar'));
 });
 
-test('ignore non values', function() {
-    assert.deepEqual({ foo: '%1', bar: 'bar' }, cookie.parse('foo=%1;bar=bar;HttpOnly;Secure'));
+test('httpOnly', function() {
+    assert.deepEqual({ foo: 'foo', HttpOnly: true }, cookie.parse('foo=foo;HttpOnly'));
+});
+
+test('secure', function() {
+    assert.deepEqual({ foo: 'foo', Secure: true }, cookie.parse('foo=foo;Secure'));
 });
 
 test('unencoded', function() {


### PR DESCRIPTION
I understand your explanation in #45 but I'm using your lib to test an API and I wanted to verify the Set-Cookie header from a response so I needed this simple fix.

Maybe we need something more elaborate to parse Cookie header and Set-Cookie header differently.