### PR TITLE
Test node stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
     - "3.3"
     - "4.0"
     - "4.2"
+    - "node"
 sudo: false
 before_install:
   # Setup Node.js version-specific dependencies


### PR DESCRIPTION
I added `node` to the matrix of versions. `node` is a pointer to latest node, actually 5.5.