### PR TITLE
Allow parsing of comma-separated cookie values.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ exports.serialize = serialize;
 
 var decode = decodeURIComponent;
 var encode = encodeURIComponent;
-var pairSplitRegExp = /; */;
+var pairSplitRegExp = /[;,] */;
 
 /**
  * RegExp to match field-content in RFC 7230 sec 3.2


### PR DESCRIPTION
resolve #62 