### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ $ npm test
 [rfc-6265-5.2.3]: https://tools.ietf.org/html/rfc6265#section-5.2.3
 [rfc-6265-5.2.4]: https://tools.ietf.org/html/rfc6265#section-5.2.4
 [rfc-6265-5.2.5]: https://tools.ietf.org/html/rfc6265#section-5.2.5
+[rfc-6265-5.2.6]: https://tools.ietf.org/html/rfc6265#section-5.2.6
 [rfc-6265-5.3]: https://tools.ietf.org/html/rfc6265#section-5.3
 
 ## License


### PR DESCRIPTION
HTTP only docs references https://tools.ietf.org/html/rfc6265#section-5.2.6 but there is no `[...]: ...` definition for it.

There is another broken link on https://www.npmjs.com/package/cookie under header `secure` because it mistakenly refers to RFC 6266, but that seems to have been fixed already.