### PR TITLE
add serializeObject export to serialize multiple cookies at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ the `Secure` attribute is set, otherwise it is not. By default, the `Secure` att
 **note** be careful when setting this to `true`, as compliant clients will not send the cookie back to
 the server in the future if the browser does not have an HTTPS connection.
 
+### cookie.serializeObject(cookies, options)
+
+Serialize an object of multiple cookie name-value pairs into an array of `Set-Cookie` header strings. The `cookies` argument is an
+object containing cookie name-value pairs and the `options` argument is a set of options that will be passed to `cookie.serialize`
+and applied to each cookie name-value pair in `cookies`.
+
+```js
+var cookies = cookie.serializeObject({foo: 'bar', bar: 'foo'}, {httpOnly: true});
+// ['foo=bar; HttpOnly', 'bar=foo; HttpOnly']
+```
+
 ## Example
 
 The following example uses this module in conjunction with the Node.js core HTTP server

--- a/benchmark/serializeObject.js
+++ b/benchmark/serializeObject.js
@@ -1,0 +1,61 @@
+/**
+ * Module dependencies.
+ */
+
+var benchmark = require('benchmark')
+var benchmarks = require('beautify-benchmark')
+
+/**
+ * Globals for benchmark.js
+ */
+
+global.cookie = require('..')
+
+var suite = new benchmark.Suite()
+
+suite.add({
+  name: 'simple',
+  minSamples: 100,
+  fn: "var val = cookie.serializeObject({foo: 'bar'})"
+})
+
+suite.add({
+  name: 'multiple',
+  minSamples: 100,
+  fn: "var val = cookie.serializeObject({foo: 'bar', bar: 'foo'})"
+})
+
+suite.add({
+  name: '10 cookies',
+  minSamples: 100,
+  fn: 'var val = cookie.serializeObject(' + JSON.stringify(gencookies(10)) + ')'
+})
+
+suite.add({
+  name: '100 cookies',
+  minSamples: 100,
+  fn: 'var val = cookie.serializeObject(' + JSON.stringify(gencookies(100)) + ')'
+})
+
+suite.on('start', function onCycle (event) {
+  process.stdout.write('  cookie.serializeObject\n\n')
+})
+
+suite.on('cycle', function onCycle (event) {
+  benchmarks.add(event.target)
+})
+
+suite.on('complete', function onComplete () {
+  benchmarks.log()
+})
+
+suite.run({async: false})
+
+function gencookies (num) {
+  var obj = {}
+
+  for (var i = 0; i < num; i++) {
+    obj['foo' + i] = 'bar';  }
+
+  return obj
+}

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@
 
 exports.parse = parse;
 exports.serialize = serialize;
+exports.serializeObject = serializeObject;
 
 /**
  * Module variables.
@@ -85,8 +86,8 @@ function parse(str, options) {
 /**
  * Serialize data into a cookie header.
  *
- * Serialize the a name value pair into a cookie string suitable for
- * http headers. An optional options object specified cookie parameters.
+ * Serialize a name value pair into a cookie string suitable for
+ * http headers. An optional options object specifies cookie parameters.
  *
  * serialize('foo', 'bar', { httpOnly: true })
  *   => "foo=bar; httpOnly"
@@ -179,6 +180,37 @@ function serialize(name, val, options) {
   }
 
   return str;
+}
+
+/**
+ * Serialize multiple cookies.
+ *
+ * Serialize an object of multiple name value pairs into cookie strings suitable for
+ * http headers. An optional options object specifies cookie parameters
+ * and will be applied to each name value pair.
+ *
+ * serializeObjet({foo: 'bar', bar: 'foo'}, { httpOnly: true })
+ *   => ["foo=bar; httpOnly", "bar=foo; httpOnly"]
+ *
+ * @param {object} cookies
+ * @param {object} [options]
+ * @return {array}
+ * @public
+ */
+
+function serializeObject(cookies, options) {
+  if (typeof cookies !== 'object') {
+    throw new TypeError('cookies must be an object');
+  }
+
+  var cookieArray = Object.keys(cookies);
+
+  for (var i = 0; i < cookieArray.length; i++) {
+    var name = cookieArray[i];
+    cookieArray[i] = serialize(name, cookies[name], options);
+  }
+
+  return cookieArray;
 }
 
 /**

--- a/test/serializeObject.js
+++ b/test/serializeObject.js
@@ -1,0 +1,160 @@
+// builtin
+var assert = require('assert');
+
+var cookie = require('..');
+
+suite('serializeObject');
+
+test('basic', function() {
+  assert.deepEqual(['foo=bar'], cookie.serializeObject({foo: 'bar'}));
+  assert.deepEqual(['foo=bar', 'bar=foo'], cookie.serializeObject({foo: 'bar', bar: 'foo'}));
+  assert.deepEqual(['foo=bar%20baz'], cookie.serializeObject({foo: 'bar baz'}));
+  assert.deepEqual(['foo='], cookie.serializeObject({foo: ''}));
+  assert.throws(cookie.serializeObject.bind(cookie, "invalid"), /cookies must be an object/);
+  assert.throws(cookie.serializeObject.bind(cookie, {'foo\n': 'bar'}), /argument name is invalid/);
+  assert.throws(cookie.serializeObject.bind(cookie, {'foo\u280a': 'bar'}), /argument name is invalid/);
+  assert.throws(cookie.serializeObject.bind(cookie, {'foo': 'bar'}, {encode: 42}), /option encode is invalid/);
+});
+
+test('path', function() {
+  assert.deepEqual(['foo=bar; Path=/'], cookie.serializeObject({foo: 'bar'}, {
+    path: '/'
+  }));
+
+  assert.throws(cookie.serializeObject.bind(cookie, {foo: 'bar'}, {
+    path: '/\n'
+  }), /option path is invalid/);
+});
+
+test('secure', function() {
+  assert.deepEqual(['foo=bar; Secure'], cookie.serializeObject({foo: 'bar'}, {
+    secure: true
+  }));
+
+  assert.deepEqual(['foo=bar'], cookie.serializeObject({foo: 'bar'}, {
+    secure: false
+  }));
+});
+
+test('domain', function() {
+  assert.deepEqual(['foo=bar; Domain=example.com'], cookie.serializeObject({foo: 'bar'}, {
+    domain: 'example.com'
+  }));
+
+  assert.throws(cookie.serializeObject.bind(cookie, {foo: 'bar'}, {
+    domain: 'example.com\n'
+  }), /option domain is invalid/);
+});
+
+test('httpOnly', function() {
+  assert.deepEqual(['foo=bar; HttpOnly', 'bar=foo; HttpOnly'], cookie.serializeObject({foo: 'bar', bar: 'foo'}, {
+    httpOnly: true
+  }));
+});
+
+test('maxAge', function() {
+  assert.throws(function () {
+    cookie.serializeObject({foo: 'bar'}, {
+      maxAge: 'buzz'
+    });
+  }, /maxAge should be a Number/);
+
+  assert.deepEqual(['foo=bar; Max-Age=1000'], cookie.serializeObject({foo: 'bar'}, {
+    maxAge: 1000
+  }));
+
+  assert.deepEqual(['foo=bar; Max-Age=1000'], cookie.serializeObject({foo: 'bar'}, {
+    maxAge: '1000'
+  }));
+
+  assert.deepEqual(['foo=bar; Max-Age=0'], cookie.serializeObject({foo: 'bar'}, {
+    maxAge: 0
+  }));
+
+  assert.deepEqual(['foo=bar; Max-Age=0'], cookie.serializeObject({foo: 'bar'}, {
+    maxAge: '0'
+  }));
+
+  assert.deepEqual(['foo=bar'], cookie.serializeObject({foo: 'bar'}, {
+    maxAge: null
+  }));
+
+  assert.deepEqual(['foo=bar'], cookie.serializeObject({foo: 'bar'}, {
+    maxAge: undefined
+  }));
+
+  assert.deepEqual(['foo=bar; Max-Age=3'], cookie.serializeObject({foo: 'bar'}, {
+    maxAge: 3.14
+  }));
+});
+
+test('expires', function() {
+  assert.deepEqual(['foo=bar; Expires=Sun, 24 Dec 2000 10:30:59 GMT'], cookie.serializeObject({foo: 'bar'}, {
+    expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900))
+  }));
+
+  assert.throws(cookie.serializeObject.bind(cookie, {foo: 'bar'}, {
+    expires: Date.now()
+  }), /option expires is invalid/);
+});
+
+test('sameSite', function() {
+  assert.deepEqual(['foo=bar; SameSite=Strict'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: true
+  }));
+
+  assert.deepEqual(['foo=bar; SameSite=Strict'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: 'Strict'
+  }));
+
+  assert.deepEqual(['foo=bar; SameSite=Strict'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: 'strict'
+  }));
+
+  assert.deepEqual(['foo=bar; SameSite=Lax'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: 'Lax'
+  }));
+
+  assert.deepEqual(['foo=bar; SameSite=Lax'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: 'lax'
+  }));
+
+  assert.deepEqual(['foo=bar; SameSite=None'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: 'None'
+  }));
+
+  assert.deepEqual(['foo=bar; SameSite=None'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: 'none'
+  }));
+
+  assert.deepEqual(['foo=bar'], cookie.serializeObject({foo: 'bar'}, {
+    sameSite: false
+  }));
+
+  assert.throws(cookie.serializeObject.bind(cookie, {foo: 'bar'}, {
+    sameSite: 'foo'
+  }), /option sameSite is invalid/);
+});
+
+test('escaping', function() {
+  assert.deepEqual(['cat=%2B%20'], cookie.serializeObject({cat: '+ '}));
+});
+
+test('parse->serialize', function() {
+
+  assert.deepEqual({ cat: 'foo=123&name=baz five' }, cookie.parse(
+    cookie.serializeObject({'cat': 'foo=123&name=baz five'})[0]));
+
+  assert.deepEqual({ cat: ' ";/' }, cookie.parse(
+    cookie.serializeObject({cat: ' ";/'})[0]));
+});
+
+test('unencoded', function() {
+  assert.deepEqual('cat=+ ', cookie.serializeObject({cat: '+ '}, {
+    encode: function(value) { return value; }
+  })[0]);
+
+  assert.throws(cookie.serializeObject.bind(cookie, {cat: '+ \n'}, {
+    encode: function(value) { return value; }
+  }), /argument val is invalid/);
+})


### PR DESCRIPTION
Proposal for issue https://github.com/jshttp/cookie/issues/30

Alternative approach from PR https://github.com/jshttp/cookie/pull/47

```js
var cookie = require('cookie');

var cookies = cookie.serializeObject({foo: 'bar', bar: 'foo'}, {httpOnly: true});
// ['foo=bar; HttpOnly', 'bar=foo; HttpOnly']
```