### PR TITLE
Bug: invalid value Infinity for maxAge

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix `maxAge` option to reject invalid values
+
 0.4.0 / 2019-05-15
 ==================
 

--- a/index.js
+++ b/index.js
@@ -120,7 +120,11 @@ function serialize(name, val, options) {
 
   if (null != opt.maxAge) {
     var maxAge = opt.maxAge - 0;
-    if (isNaN(maxAge)) throw new Error('maxAge should be a Number');
+
+    if (isNaN(maxAge) || !isFinite(maxAge)) {
+      throw new TypeError('option maxAge is invalid')
+    }
+
     str += '; Max-Age=' + Math.floor(maxAge);
   }
 

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -55,7 +55,13 @@ test('maxAge', function() {
     cookie.serialize('foo', 'bar', {
       maxAge: 'buzz'
     });
-  }, /maxAge should be a Number/);
+  }, /option maxAge is invalid/)
+
+  assert.throws(function () {
+    cookie.serialize('foo', 'bar', {
+      maxAge: Infinity
+    })
+  }, /option maxAge is invalid/)
 
   assert.equal('foo=bar; Max-Age=1000', cookie.serialize('foo', 'bar', {
     maxAge: 1000


### PR DESCRIPTION
Regarding issue #103, We should handle +Infinity and -Infinity for maxAge value