### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/benchmark/parse-top.js
+++ b/benchmark/parse-top.js
@@ -43,5 +43,5 @@ function gencookies (num) {
     str += '; foo' + i + '=bar'
   }
 
-  return str.substr(2)
+  return str.slice(2)
 }

--- a/benchmark/parse.js
+++ b/benchmark/parse.js
@@ -70,5 +70,5 @@ function gencookies (num) {
     str += '; foo' + i + '=bar'
   }
 
-  return str.substr(2)
+  return str.slice(2)
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.