### PR TITLE
added support for partitioned key as per new Chrome regulations

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,10 @@ function serialize(name, val, options) {
         throw new TypeError('option sameSite is invalid');
     }
   }
+  
+  if (opt.partitioned) {
+    str += '; Partitioned';
+  }
 
   return str;
 }

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -193,4 +193,14 @@ describe('cookie.serialize(name, value, options)', function () {
       assert.equal(cookie.serialize('foo', 'bar', { secure: false }), 'foo=bar')
     })
   })
+  
+  describe('with "partitioned" option', function () {
+    it('should include partitioned flag when true', function () {
+      assert.equal(cookie.serialize('foo', 'bar', { partitioned: true }), 'foo=bar; Partitioned')
+    })
+
+    it('should not include partitioned flag when false', function () {
+      assert.equal(cookie.serialize('foo', 'bar', { partitioned: false }), 'foo=bar')
+    })
+  })
 })


### PR DESCRIPTION
As per new Chrome regulations for third party cookie, which would be blocked, partitioned must be sent to ensure a separate cookie jar in maintained.

Refer new changes for third party cookie here: <https://developer.chrome.com/en/docs/privacy-sandbox/chips/>
