### PR TITLE
fix: expires date validation for other date formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,13 +155,20 @@ function serialize(name, val, options) {
   }
 
   if (opt.expires) {
-    var expires = opt.expires
+    var expires = opt.expires;
 
-    if (!isDate(expires) || isNaN(expires.valueOf())) {
-      throw new TypeError('option expires is invalid');
+    if (!isDate(expires)) {
+        // Attempt to parse the date in ISO 8601 or a custom format
+        expires = new Date(expires);
+
+        // Check if the parsed date is valid
+        if (isNaN(expires.valueOf())) {
+            throw new TypeError('option expires is invalid');
+        }
     }
 
-    str += '; Expires=' + expires.toUTCString()
+    // Use the expires date for setting the Expires header
+    str += '; Expires=' + expires.toUTCString();
   }
 
   if (opt.httpOnly) {


### PR DESCRIPTION
**Problem:**
When I was working with [AuthJS](https://authjs.dev/), your 'cookie' module currently throws an error when the 'expires' option is provided in a non-standard date format, such as "2023-11-26T09:50:03.088Z." This error limits the flexibility of date handling in the module.

I printed what `opt.expires` would be, and the second 'it me' is the one AuthJS provides, to my understanding:

```
[next] it me Fri Oct 27 2023 12:05:00 GMT+0200 (GMT+02:00)
[next] it me 2023-11-26T09:50:03.088Z
[next] - error node_modules/.pnpm/cookie@0.5.0/node_modules/cookie/index.js (161:12) @ serialize
[next] - error option expires is invalid
```

**Solution:**
This PR updates the code to handle a broader range of date formats for the 'expires' option by using the JavaScript `Date` constructor for parsing.

**Testing:**
I tested that the changes support previous edge cases and my case format that previously caused an error.

**Additional Notes:**
This change doesn't impact other functionality and maintains compatibility with existing code while enhancing date format flexibility.

Your feedback on this fix is appreciated. Thank you for reviewing the PR.