### PR TITLE
Feature: Add standard codes to serialize TypeErrors

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,17 +113,23 @@ function serialize(name, val, options) {
   var enc = opt.encode || encode;
 
   if (typeof enc !== 'function') {
-    throw new TypeError('option encode is invalid');
+    var encodeError = new TypeError('option encode is invalid')
+    encodeError.code = 'ERR_INVALID_ARG_TYPE'
+    throw encodeError
   }
 
   if (!fieldContentRegExp.test(name)) {
-    throw new TypeError('argument name is invalid');
+    var nameError = new TypeError('argument name is invalid')
+    nameError.code = 'ERR_INVALID_ARG_VALUE'
+    throw nameError;
   }
 
   var value = enc(val);
 
   if (value && !fieldContentRegExp.test(value)) {
-    throw new TypeError('argument val is invalid');
+    var returnError = new TypeError('argument val is invalid')
+    returnError.code = 'ERR_INVALID_RETURN_VALUE'
+    throw returnError;
   }
 
   var str = name + '=' + value;
@@ -132,7 +138,9 @@ function serialize(name, val, options) {
     var maxAge = opt.maxAge - 0;
 
     if (isNaN(maxAge) || !isFinite(maxAge)) {
-      throw new TypeError('option maxAge is invalid')
+      var maxAgeError = new TypeError('option maxAge is invalid')
+      maxAgeError.code = 'ERR_INVALID_ARG_VALUE'
+      throw maxAgeError;
     }
 
     str += '; Max-Age=' + Math.floor(maxAge);
@@ -140,7 +148,9 @@ function serialize(name, val, options) {
 
   if (opt.domain) {
     if (!fieldContentRegExp.test(opt.domain)) {
-      throw new TypeError('option domain is invalid');
+      var domainError = new TypeError('option domain is invalid')
+      domainError.code = 'ERR_INVALID_ARG_VALUE'
+      throw domainError;
     }
 
     str += '; Domain=' + opt.domain;
@@ -148,7 +158,9 @@ function serialize(name, val, options) {
 
   if (opt.path) {
     if (!fieldContentRegExp.test(opt.path)) {
-      throw new TypeError('option path is invalid');
+      var pathError = new TypeError('option path is invalid')
+      pathError.code = 'ERR_INVALID_ARG_VALUE'
+      throw pathError;
     }
 
     str += '; Path=' + opt.path;
@@ -156,9 +168,14 @@ function serialize(name, val, options) {
 
   if (opt.expires) {
     var expires = opt.expires
+    var expiresError = new TypeError('option expires is invalid')
 
-    if (!isDate(expires) || isNaN(expires.valueOf())) {
-      throw new TypeError('option expires is invalid');
+    if (!isDate(expires)) {
+      expiresError.code = 'ERR_INVALID_ARG_TYPE'
+      throw expiresError;
+    } else if (isNaN(expires.valueOf())) {
+      expiresError.code = 'ERR_INVALID_ARG_VALUE'
+      throw expiresError;
     }
 
     str += '; Expires=' + expires.toUTCString()
@@ -177,9 +194,13 @@ function serialize(name, val, options) {
   }
 
   if (opt.priority) {
-    var priority = typeof opt.priority === 'string'
-      ? opt.priority.toLowerCase()
-      : opt.priority
+    var priorityError = new TypeError('option priority is invalid')
+    if (typeof opt.priority !== 'string') {
+      priorityError.code = 'ERR_INVALID_ARG_TYPE'
+      throw priorityError;
+    }
+
+    var priority = opt.priority.toLowerCase()
 
     switch (priority) {
       case 'low':
@@ -192,7 +213,8 @@ function serialize(name, val, options) {
         str += '; Priority=High'
         break
       default:
-        throw new TypeError('option priority is invalid')
+        priorityError.code = 'ERR_INVALID_ARG_VALUE'
+        throw priorityError;
     }
   }
 
@@ -214,7 +236,11 @@ function serialize(name, val, options) {
         str += '; SameSite=None';
         break;
       default:
-        throw new TypeError('option sameSite is invalid');
+        var sameSiteError = new TypeError('option sameSite is invalid')
+        sameSiteError.code = typeof opt.sameSite === 'string'
+          ? 'ERR_INVALID_ARG_VALUE'
+          : 'ERR_INVALID_ARG_TYPE'
+        throw sameSiteError;
     }
   }
 

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -18,8 +18,20 @@ describe('cookie.serialize(name, value)', function () {
   })
 
   it('should throw for invalid name', function () {
-    assert.throws(cookie.serialize.bind(cookie, 'foo\n', 'bar'), /argument name is invalid/)
-    assert.throws(cookie.serialize.bind(cookie, 'foo\u280a', 'bar'), /argument name is invalid/)
+    assert.throws(
+      cookie.serialize.bind(cookie, 'foo\n', 'bar'),
+      {
+        message: 'argument name is invalid',
+        code: 'ERR_INVALID_ARG_VALUE',
+      }
+    )
+    assert.throws(
+      cookie.serialize.bind(cookie, 'foo\u280a', 'bar'),
+      {
+        message: 'argument name is invalid',
+        code: 'ERR_INVALID_ARG_VALUE',
+      }
+    )
   })
 })
 
@@ -31,15 +43,25 @@ describe('cookie.serialize(name, value, options)', function () {
     })
 
     it('should throw for invalid value', function () {
-      assert.throws(cookie.serialize.bind(cookie, 'foo', 'bar', { domain: 'example.com\n' }),
-        /option domain is invalid/)
+      assert.throws(
+        cookie.serialize.bind(cookie, 'foo', 'bar', { domain: 'example.com\n' }),
+        {
+          message: 'option domain is invalid',
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      )
     })
   })
 
   describe('with "encode" option', function () {
     it('should throw on non-function value', function () {
-      assert.throws(cookie.serialize.bind(cookie, 'foo', 'bar', { encode: 42 }),
-        /option encode is invalid/)
+      assert.throws(
+        cookie.serialize.bind(cookie, 'foo', 'bar', { encode: 42 }),
+        {
+          message: 'option encode is invalid',
+          code: 'ERR_INVALID_ARG_TYPE',
+        }
+      )
     })
 
     it('should specify alternative value encoder', function () {
@@ -49,21 +71,37 @@ describe('cookie.serialize(name, value, options)', function () {
     })
 
     it('should throw when returned value is invalid', function () {
-      assert.throws(cookie.serialize.bind(cookie, 'foo', '+ \n', {
-        encode: function (v) { return v }
-      }), /argument val is invalid/)
+      assert.throws(
+        cookie.serialize.bind(cookie, 'foo', '+ \n', {
+          encode: function (v) { return v }
+        }),
+        {
+          message: 'argument val is invalid',
+          code: 'ERR_INVALID_RETURN_VALUE',
+        }
+      )
     })
   })
 
   describe('with "expires" option', function () {
     it('should throw on non-Date value', function () {
-      assert.throws(cookie.serialize.bind(cookie, 'foo', 'bar', { expires: 42 }),
-        /option expires is invalid/)
+      assert.throws(
+        cookie.serialize.bind(cookie, 'foo', 'bar', { expires: 42 }),
+        {
+          message: 'option expires is invalid',
+          code: 'ERR_INVALID_ARG_TYPE',
+        }
+      )
     })
 
     it('should throw on invalid date', function () {
-      assert.throws(cookie.serialize.bind(cookie, 'foo', 'bar', { expires: new Date(NaN) }),
-        /option expires is invalid/)
+      assert.throws(
+        cookie.serialize.bind(cookie, 'foo', 'bar', { expires: new Date(NaN) }),
+        {
+          message: 'option expires is invalid',
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      )
     })
 
     it('should set expires to given date', function () {
@@ -85,15 +123,27 @@ describe('cookie.serialize(name, value, options)', function () {
 
   describe('with "maxAge" option', function () {
     it('should throw when not a number', function () {
-      assert.throws(function () {
-        cookie.serialize('foo', 'bar', { maxAge: 'buzz' })
-      }, /option maxAge is invalid/)
+      assert.throws(
+        function () {
+          cookie.serialize('foo', 'bar', { maxAge: 'buzz' })
+        },
+        {
+          message: 'option maxAge is invalid',
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      )
     })
 
     it('should throw when Infinity', function () {
-      assert.throws(function () {
-        cookie.serialize('foo', 'bar', { maxAge: Infinity })
-      }, /option maxAge is invalid/)
+      assert.throws(
+        function () {
+          cookie.serialize('foo', 'bar', { maxAge: Infinity })
+        },
+        {
+          message: 'option maxAge is invalid',
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      )
     })
 
     it('should set max-age to value', function () {
@@ -133,22 +183,38 @@ describe('cookie.serialize(name, value, options)', function () {
     })
 
     it('should throw for invalid value', function () {
-      assert.throws(cookie.serialize.bind(cookie, 'foo', 'bar', { path: '/\n' }),
-        /option path is invalid/)
+      assert.throws(
+        cookie.serialize.bind(cookie, 'foo', 'bar', { path: '/\n' }),
+        {
+          message: 'option path is invalid',
+          code: 'ERR_INVALID_ARG_VALUE',
+        }      )
     })
   })
 
   describe('with "priority" option', function () {
     it('should throw on invalid priority', function () {
-      assert.throws(function () {
-        cookie.serialize('foo', 'bar', { priority: 'foo' })
-      }, /option priority is invalid/)
+      assert.throws(
+        function () {
+          cookie.serialize('foo', 'bar', { priority: 'foo' })
+        },
+        {
+          message: 'option priority is invalid',
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      )
     })
 
     it('should throw on non-string', function () {
-      assert.throws(function () {
-        cookie.serialize('foo', 'bar', { priority: 42 })
-      }, /option priority is invalid/)
+      assert.throws(
+        function () {
+          cookie.serialize('foo', 'bar', { priority: 42 })
+        },
+        {
+          message: 'option priority is invalid',
+          code: 'ERR_INVALID_ARG_TYPE',
+        }
+      )
     })
 
     it('should set priority low', function () {
@@ -169,9 +235,15 @@ describe('cookie.serialize(name, value, options)', function () {
 
   describe('with "sameSite" option', function () {
     it('should throw on invalid sameSite', function () {
-      assert.throws(function () {
-        cookie.serialize('foo', 'bar', { sameSite: 'foo' })
-      }, /option sameSite is invalid/)
+      assert.throws(
+        function () {
+          cookie.serialize('foo', 'bar', { sameSite: 'foo' })
+        },
+        {
+          message: 'option sameSite is invalid',
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      )
     })
 
     it('should set sameSite strict', function () {

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -246,6 +246,18 @@ describe('cookie.serialize(name, value, options)', function () {
       )
     })
 
+    it('should throw on non-string/non-true', function () {
+      assert.throws(
+        function () {
+          cookie.serialize('foo', 'bar', { sameSite: 42 })
+        },
+        {
+          message: 'option sameSite is invalid',
+          code: 'ERR_INVALID_ARG_TYPE',
+        }
+      )
+    })
+
     it('should set sameSite strict', function () {
       assert.equal(cookie.serialize('foo', 'bar', { sameSite: 'Strict' }), 'foo=bar; SameSite=Strict')
       assert.equal(cookie.serialize('foo', 'bar', { sameSite: 'strict' }), 'foo=bar; SameSite=Strict')


### PR DESCRIPTION
As requested in #162 as a non-breaking change prior to a change of error messages for a future major release, standard Node error codes have been added to each of the `serialize` function's TypeError throws.

This should allow for a period of migrating for library users to error-handling via the `.code` error property, as opposed to the sole `.message` property, before they change (potentially breaking).

## This PR

- Amends existing `serialize` tests to test for the correct error message and error code.
- Adds a sameSite test for non-string/true argument values.
- Adds `.code` properties with standard Node error codes to each error throw in the `serialize` function.