### PR TITLE
Fix exports for some bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "SECURITY.md",
     "index.js"
   ],
+  "main": "index.js",
   "engines": {
     "node": ">= 0.6"
   },


### PR DESCRIPTION
I've been using this package in a javascript library with esbuild and it's worked fine, but for some reason, rspack can't resolve it. Adding `"main": "index.js"` to package.json fixed this.