### PR TITLE
fix: narrow the validation of cookies to match RFC6265

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ var cookieValueRegExp = /^("?)[\u0021\u0023-\u002B\u002D-\u003A\u003C-\u005B\u00
  *                     upper case and a through z in lower case
  * <digit>           = any one of the ten digits 0 through 9
  */
+ 
 var domainValueRegExp = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)([.][a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/i;
 
 /**

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var __toString = Object.prototype.toString
  * RegExp to match cookie-name in RFC 6265 sec 4.1.1
  * This refers out to the obsoleted definition of token in RFC 2616 sec 2.2
  * which has been replaced by the token definition in RFC 7230 appendix B.
- * 
+ *
  * cookie-name       = token
  * token             = 1*tchar
  * tchar             = "!" / "#" / "$" / "%" / "&" / "'" /
@@ -36,7 +36,7 @@ var __toString = Object.prototype.toString
 
 var cookieNameRegExp = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
-/** 
+/**
  * RegExp to match cookie-value in RFC 6265 sec 4.1.1
  *
  * cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
@@ -46,7 +46,7 @@ var cookieNameRegExp = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
  *                     ; and backslash
  */
 
-var  cookieValueRegExp = /^("?)[\u0021\u0023-\u002B\u002D-\u003A\u003C-\u005B\u005D-\u007E]*\1$/;
+var cookieValueRegExp = /^("?)[\u0021\u0023-\u002B\u002D-\u003A\u003C-\u005B\u005D-\u007E]*\1$/;
 
 /**
  * RegExp to match domain-value in RFC 6265 sec 4.1.1
@@ -65,7 +65,7 @@ var  cookieValueRegExp = /^("?)[\u0021\u0023-\u002B\u002D-\u003A\u003C-\u005B\u0
  *                     upper case and a through z in lower case
  * <digit>           = any one of the ten digits 0 through 9
  */
-var  domainValueRegExp = /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)([.][a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+var domainValueRegExp = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)([.][a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/i;
 
 /**
  * RegExp to match path-value in RFC 6265 sec 4.1.1
@@ -73,7 +73,7 @@ var  domainValueRegExp = /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)([.][a-z
  * path-value        = <any CHAR except CTLs or ";">
  */
 
-var  pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
+var pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
 
 /**
  * Parse a cookie header.

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var cookieValueRegExp = /^("?)[\u0021\u0023-\u002B\u002D-\u003A\u003C-\u005B\u00
  *                     upper case and a through z in lower case
  * <digit>           = any one of the ten digits 0 through 9
  */
- 
+
 var domainValueRegExp = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)([.][a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/i;
 
 /**

--- a/index.js
+++ b/index.js
@@ -23,14 +23,57 @@ exports.serialize = serialize;
 var __toString = Object.prototype.toString
 
 /**
- * RegExp to match field-content in RFC 7230 sec 3.2
- *
- * field-content = field-vchar [ 1*( SP / HTAB ) field-vchar ]
- * field-vchar   = VCHAR / obs-text
- * obs-text      = %x80-FF
+ * RegExp to match cookie-name in RFC 6265 sec 4.1.1
+ * This refers out to the obsoleted definition of token in RFC 2616 sec 2.2
+ * which has been replaced by the token definition in RFC 7230 appendix B.
+ * 
+ * cookie-name       = token
+ * token             = 1*tchar
+ * tchar             = "!" / "#" / "$" / "%" / "&" / "'" /
+ *                     "*" / "+" / "-" / "." / "^" / "_" /
+ *                     "`" / "|" / "~" / DIGIT / ALPHA
  */
 
-var fieldContentRegExp = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/;
+var cookieNameRegExp = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+
+/** 
+ * RegExp to match cookie-value in RFC 6265 sec 4.1.1
+ *
+ * cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
+ * cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+ *                     ; US-ASCII characters excluding CTLs,
+ *                     ; whitespace DQUOTE, comma, semicolon,
+ *                     ; and backslash
+ */
+
+var  cookieValueRegExp = /^("?)[\u0021\u0023-\u002B\u002D-\u003A\u003C-\u005B\u005D-\u007E]*\1$/;
+
+/**
+ * RegExp to match domain-value in RFC 6265 sec 4.1.1
+ *
+ * domain-value      = <subdomain>
+ *                     ; defined in [RFC1034], Section 3.5, as
+ *                     ; enhanced by [RFC1123], Section 2.1
+ * <subdomain>       = <label> | <subdomain> "." <label>
+ * <label>           = <let-dig> [ [ <ldh-str> ] <let-dig> ]
+ *                     Labels must be 63 characters or less.
+ *                     'let-dig' not 'letter' in the first char, per RFC1123
+ * <ldh-str>         = <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+ * <let-dig-hyp>     = <let-dig> | "-"
+ * <let-dig>         = <letter> | <digit>
+ * <letter>          = any one of the 52 alphabetic characters A through Z in
+ *                     upper case and a through z in lower case
+ * <digit>           = any one of the ten digits 0 through 9
+ */
+var  domainValueRegExp = /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)([.][a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+/**
+ * RegExp to match path-value in RFC 6265 sec 4.1.1
+ *
+ * path-value        = <any CHAR except CTLs or ";">
+ */
+
+var  pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
 
 /**
  * Parse a cookie header.
@@ -116,13 +159,13 @@ function serialize(name, val, options) {
     throw new TypeError('option encode is invalid');
   }
 
-  if (!fieldContentRegExp.test(name)) {
+  if (!cookieNameRegExp.test(name)) {
     throw new TypeError('argument name is invalid');
   }
 
   var value = enc(val);
 
-  if (value && !fieldContentRegExp.test(value)) {
+  if (value && !cookieValueRegExp.test(value)) {
     throw new TypeError('argument val is invalid');
   }
 
@@ -139,7 +182,7 @@ function serialize(name, val, options) {
   }
 
   if (opt.domain) {
-    if (!fieldContentRegExp.test(opt.domain)) {
+    if (!domainValueRegExp.test(opt.domain)) {
       throw new TypeError('option domain is invalid');
     }
 
@@ -147,7 +190,7 @@ function serialize(name, val, options) {
   }
 
   if (opt.path) {
-    if (!fieldContentRegExp.test(opt.path)) {
+    if (!pathValueRegExp.test(opt.path)) {
       throw new TypeError('option path is invalid');
     }
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var __toString = Object.prototype.toString
  *                     "`" / "|" / "~" / DIGIT / ALPHA
  */
 
-var cookieNameRegExp = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+var cookieNameRegExp = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 /**
  * RegExp to match cookie-value in RFC 6265 sec 4.1.1

--- a/index.js
+++ b/index.js
@@ -71,6 +71,8 @@ var domainValueRegExp = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)([.][a-z0-9]([a-z0
  * RegExp to match path-value in RFC 6265 sec 4.1.1
  *
  * path-value        = <any CHAR except CTLs or ";">
+ * CHAR              = %x01-7F
+ *                     ; defined in RFC 5234 appendix B.1
  */
 
 var pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -20,6 +20,7 @@ describe('cookie.serialize(name, value)', function () {
   it('should throw for invalid name', function () {
     assert.throws(cookie.serialize.bind(cookie, 'foo\n', 'bar'), /argument name is invalid/)
     assert.throws(cookie.serialize.bind(cookie, 'foo\u280a', 'bar'), /argument name is invalid/)
+    assert.throws(cookie.serialize.bind(cookie, 'foo bar', 'bar'), /argument name is invalid/)
   })
 })
 
@@ -50,6 +51,9 @@ describe('cookie.serialize(name, value, options)', function () {
 
     it('should throw when returned value is invalid', function () {
       assert.throws(cookie.serialize.bind(cookie, 'foo', '+ \n', {
+        encode: function (v) { return v }
+      }), /argument val is invalid/)
+      assert.throws(cookie.serialize.bind(cookie, 'foo', 'foo bar', {
         encode: function (v) { return v }
       }), /argument val is invalid/)
     })


### PR DESCRIPTION
fixes #165. Previously, validation on serialization used the field-content regexp from RFC7230 to perform all checks. However, that is the regexp for the cookie header as a whole, but each individual part of a cookie has a tighter restriction.

In the bug report #165 I demonstrated that whitespace in names and values was invalid but allowed by the field-content pattern. In this code I started by adding tests for those two cases, then added the expressions derived from the RFC; the relevant portions of the RFC have been inlined as comments.

Removing the field-content regexp unearthed that as well as those two it was being used to validate domain names and paths. Paths are fairly unrestricted (being any ascii character except control characters and semicolon) but the code was wrong here too - it allowed all 8-bit characters not just 7-bit characters.

Domain names have a well recognised pattern, there are only a couple of gotchas: RFC6265 explicitly says RFC1123 applies, so the leading character of a label is allowed to be a digit; and while I wondered for a moment if this should allow things like [::1] the domain matching section of https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3 teaches that domain values are _not_ ip addresses.