### PR TITLE
fix(serialize): added regex validation for cookie name

### DIFF
--- a/test/serialize.js
+++ b/test/serialize.js
@@ -66,3 +66,57 @@ test('unencoded', function() {
         encode: function(value) { return value; }
     }));
 })
+
+// Test for valid cookie names
+test('valid cookie names', function() {
+  var validCookieNames = [
+    'user_id-123',
+    'SESSION-TOKEN_v2',
+    'auth0.jwt.token',
+    '__Secure-ID',
+    'csrf_token!valid',
+    'tracking-cookie$main_version',
+    'analytics%5Bsource%5D',
+    'persistent_001#abc',
+    'first|last'
+  ];
+
+  validCookieNames.forEach(function(name) {
+    var expectedCookie = {};
+    expectedCookie[name] = 'test_value'; // Dynamically set the property name
+
+    assert.deepEqual(
+      expectedCookie, 
+      cookie.parse(cookie.serialize(name, 'test_value'))
+    );
+  });
+});
+
+// Test for invalid cookie names
+test('invalid cookie names throw error', function() {
+  var invalidCookieNames = [
+    'locale-set@en-US',
+    'cart[items][id]',
+    'mydir/username',
+    'query?id',
+    'category:cars',
+    'first,last',
+    '{id:123}',
+    'no spaces allowed',
+    'no\ttabs\tallowed',
+    'foo<scriptalertscript',
+    'userId=<script>alert(%27XSS7%27)</script>;+Max-Age=2592000;+a',
+    'token=<img src=x onerror=alert(%27XSS2%27)>;+Path=/;+Secure;',
+    'tracking=<body onload=alert(%27XSS5%27)>;+Expires=Tue, 19 Jan 2038 03:14:07 GMT;'
+  ];
+
+  invalidCookieNames.forEach(function(name) {
+    assert.throws(
+      function() {
+        cookie.serialize(name, 'test_value');
+      },
+      Error,
+      'Expected "' + name + '" to throw an error'
+    );
+  });
+});


### PR DESCRIPTION
A vulnerability exists for versions < 0.2.1 as the cookie name was not validated nor encoded to avoid 'separator' characters which lead to the ability for cookie names to be exploited for arbitrary cookie injection by passing in delimiters in the cookie name string. Starting with v0.2.1 cookie names are validated the same as cookie values per [RFC 7230 sec 3.2.6][1]

This fix adds a regex test based on [RFC 6265 sec 4.1.1][2] and [RFC 2616 sec 2.2][3] to check for valid characters allowed in cookie names. It throws an error if the criteria are not met as opposed to sanitizing the value which could lead to silent bugs and the potential for cookie name collision as different name strings could be santized to the same resultant value.

Tests also provided to ensure valid cookie names work, invalid ones error as well as a couple of attack strings.

[1]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
[2]: https://datatracker.ietf.org/doc/html/rfc2616#section-2.2
[3]: https://datatracker.ietf.org/doc/html/rfc2616#section-2.2