### PR TITLE
Iterate whitespace for perf

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,13 +102,13 @@ function parse(str, options) {
   var index = 0;
 
   while (index < str.length) {
-    var eqIdx = str.indexOf('=', index);
-    if (eqIdx === -1) break;
-
     var endIdx = str.indexOf(';', index);
     if (endIdx === -1) endIdx = str.length;
 
-    if (eqIdx > endIdx) {
+    var eqIdx = index;
+    while (eqIdx < endIdx && str.charCodeAt(eqIdx) !== 0x3D /* = */) eqIdx++;
+
+    if (eqIdx === endIdx) {
       index = endIdx + 1;
       continue;
     }

--- a/index.js
+++ b/index.js
@@ -100,19 +100,23 @@ function parse(str, options) {
   var dec = opt.decode || decode;
 
   var index = 0;
+  var eqIdx = 0;
+  var endIdx = 0;
+  var len = str.length;
+  var max = len - 2;
 
-  while (index < str.length) {
-    var eqIdx = str.indexOf('=', index);
+  while (index < max) {
+    eqIdx = str.indexOf('=', index);
 
     // no more cookie pairs
     if (eqIdx === -1) {
       break;
     }
 
-    var endIdx = str.indexOf(';', index);
+    endIdx = str.indexOf(';', index);
 
     if (endIdx === -1) {
-      endIdx = str.length;
+      endIdx = len;
     } else if (eqIdx > endIdx) {
       // backtrack on prior semicolon
       index = str.lastIndexOf(';', eqIdx - 1) + 1;

--- a/index.js
+++ b/index.js
@@ -114,6 +114,7 @@ function parse(str, options) {
     if (endIdx === -1) {
       endIdx = str.length;
     } else if (eqIdx > endIdx) {
+      // backtrack on prior semicolon
       index = str.lastIndexOf(';', eqIdx - 1) + 1;
       continue;
     }
@@ -150,9 +151,9 @@ function startIndex(str, index, max) {
 }
 
 function endIndex(str, index, min) {
-  do {
-    if (str.charCodeAt(index - 1) !== 0x20 /*   */) break;
-  } while (--index >= min);
+  while (index > min) {
+    if (str.charCodeAt(--index) !== 0x20 /*   */) return index + 1;
+  }
   return index;
 }
 

--- a/index.js
+++ b/index.js
@@ -102,14 +102,19 @@ function parse(str, options) {
   var index = 0;
 
   while (index < str.length) {
+    var eqIdx = str.indexOf('=', index);
+
+    // no more cookie pairs
+    if (eqIdx === -1) {
+      break;
+    }
+
     var endIdx = str.indexOf(';', index);
-    if (endIdx === -1) endIdx = str.length;
 
-    var eqIdx = index;
-    while (eqIdx < endIdx && str.charCodeAt(eqIdx) !== 0x3D /* = */) eqIdx++;
-
-    if (eqIdx === endIdx) {
-      index = endIdx + 1;
+    if (endIdx === -1) {
+      endIdx = str.length;
+    } else if (eqIdx > endIdx) {
+      index = str.lastIndexOf(';', eqIdx - 1) + 1;
       continue;
     }
 

--- a/index.js
+++ b/index.js
@@ -145,16 +145,18 @@ function parse(str, options) {
 
 function startIndex(str, index, max) {
   do {
-    if (str.charCodeAt(index) !== 0x20 /*   */) break;
+    var code = str.charCodeAt(index);
+    if (code !== 0x20 /*   */ && code !== 0x09 /* \t */) return index;
   } while (++index < max);
-  return index;
+  return max;
 }
 
 function endIndex(str, index, min) {
   while (index > min) {
-    if (str.charCodeAt(--index) !== 0x20 /*   */) return index + 1;
+    var code = str.charCodeAt(--index);
+    if (code !== 0x20 /*   */ && code !== 0x09 /* \t */) return index + 1;
   }
-  return index;
+  return min;
 }
 
 /**

--- a/test/parse.js
+++ b/test/parse.js
@@ -24,7 +24,7 @@ describe('cookie.parse(str)', function () {
   })
 
   it('should parse cookie with empty value', function () {
-    assert.deepEqual(cookie.parse('foo= ; bar='), { foo: '', bar: '' })
+    assert.deepEqual(cookie.parse('foo=; bar='), { foo: '', bar: '' })
   })
 
   it('should URL-decode values', function () {
@@ -36,12 +36,16 @@ describe('cookie.parse(str)', function () {
 
   it('should parse quoted values', function () {
     assert.deepEqual(cookie.parse('foo="bar"'), { foo: 'bar' })
+    assert.deepEqual(cookie.parse('foo=" a b c "'), { foo: ' a b c ' })
   })
 
   it('should trim whitespace around key and value', function () {
     assert.deepEqual(cookie.parse('  foo  =  "bar"  '), { foo: 'bar' })
     assert.deepEqual(cookie.parse('  foo  =  bar  ;  fizz  =  buzz  '), { foo: 'bar', fizz: 'buzz' })
-    assert.deepEqual(cookie.parse('foo=" a b c "'), { foo: ' a b c ' })
+    assert.deepEqual(cookie.parse(' foo = " a b c " '), { foo: ' a b c ' })
+    assert.deepEqual(cookie.parse(' = bar '), { '': 'bar' })
+    assert.deepEqual(cookie.parse(' foo = '), { foo: '' })
+    assert.deepEqual(cookie.parse('   =   '), { '': '' })
   })
 
   it('should return original value on escape error', function () {

--- a/test/parse.js
+++ b/test/parse.js
@@ -46,6 +46,7 @@ describe('cookie.parse(str)', function () {
     assert.deepEqual(cookie.parse(' = bar '), { '': 'bar' })
     assert.deepEqual(cookie.parse(' foo = '), { foo: '' })
     assert.deepEqual(cookie.parse('   =   '), { '': '' })
+    assert.deepEqual(cookie.parse('\tfoo\t=\tbar\t'), { foo: 'bar' })
   })
 
   it('should return original value on escape error', function () {

--- a/test/parse.js
+++ b/test/parse.js
@@ -34,6 +34,16 @@ describe('cookie.parse(str)', function () {
     assert.deepEqual(cookie.parse('email=%20%22%2c%3b%2f'), { email: ' ",;/' })
   })
 
+  it('should parse quoted values', function () {
+    assert.deepEqual(cookie.parse('foo="bar"'), { foo: 'bar' })
+  })
+
+  it('should trim whitespace around key and value', function () {
+    assert.deepEqual(cookie.parse('  foo  =  "bar"  '), { foo: 'bar' })
+    assert.deepEqual(cookie.parse('  foo  =  bar  ;  fizz  =  buzz  '), { foo: 'bar', fizz: 'buzz' })
+    assert.deepEqual(cookie.parse('foo=" a b c "'), { foo: ' a b c ' })
+  })
+
   it('should return original value on escape error', function () {
     assert.deepEqual(cookie.parse('foo=%1;bar=bar'), { foo: '%1', bar: 'bar' })
   })


### PR DESCRIPTION
Uses a loop over spaces instead of `.trim()`. Appears to be a reasonable perf improvement in testing.

Before:

```
> /Users/blakeembrey/.n/bin/node benchmark/parse-top.js

  cookie.parse - top sites

  14 tests completed.

  parse accounts.google.com x 10,690,166 ops/sec ±0.55% (194 runs sampled)
  parse apple.com           x 12,183,219 ops/sec ±0.31% (197 runs sampled)
  parse cloudflare.com      x 10,442,218 ops/sec ±0.28% (197 runs sampled)
  parse docs.google.com     x 10,084,253 ops/sec ±0.26% (196 runs sampled)
  parse drive.google.com    x 10,124,351 ops/sec ±0.22% (196 runs sampled)
  parse en.wikipedia.org    x  1,942,194 ops/sec ±0.23% (189 runs sampled)
  parse linkedin.com        x  2,183,254 ops/sec ±0.24% (193 runs sampled)
  parse maps.google.com     x  5,293,295 ops/sec ±0.23% (196 runs sampled)
  parse microsoft.com       x  3,659,868 ops/sec ±0.24% (195 runs sampled)
  parse play.google.com     x 10,503,304 ops/sec ±0.55% (197 runs sampled)
  parse support.google.com  x  6,390,620 ops/sec ±1.16% (194 runs sampled)
  parse www.google.com      x  4,176,170 ops/sec ±0.23% (195 runs sampled)
  parse youtu.be            x  2,023,661 ops/sec ±0.53% (195 runs sampled)
  parse youtube.com         x  2,032,070 ops/sec ±0.22% (197 runs sampled)

> /Users/blakeembrey/.n/bin/node benchmark/parse.js

  cookie.parse - generic

  6 tests completed.

  simple      x 13,431,777 ops/sec ±0.33% (189 runs sampled)
  decode      x  4,964,245 ops/sec ±0.29% (195 runs sampled)
  unquote     x 12,254,744 ops/sec ±0.31% (196 runs sampled)
  duplicates  x  3,428,104 ops/sec ±0.28% (195 runs sampled)
  10 cookies  x    953,884 ops/sec ±0.27% (195 runs sampled)
  100 cookies x     74,344 ops/sec ±0.57% (192 runs sampled)
```

After:

```
> /Users/blakeembrey/.n/bin/node benchmark/parse-top.js

  cookie.parse - top sites

  14 tests completed.

  parse accounts.google.com x 11,760,349 ops/sec ±0.36% (190 runs sampled)
  parse apple.com           x 13,340,320 ops/sec ±0.36% (193 runs sampled)
  parse cloudflare.com      x 11,739,042 ops/sec ±0.27% (196 runs sampled)
  parse docs.google.com     x 11,279,592 ops/sec ±0.21% (195 runs sampled)
  parse drive.google.com    x 11,118,106 ops/sec ±0.21% (195 runs sampled)
  parse en.wikipedia.org    x  2,269,686 ops/sec ±0.22% (196 runs sampled)
  parse linkedin.com        x  2,602,998 ops/sec ±1.28% (191 runs sampled)
  parse maps.google.com     x  6,016,290 ops/sec ±0.26% (192 runs sampled)
  parse microsoft.com       x  4,372,931 ops/sec ±0.43% (195 runs sampled)
  parse play.google.com     x 11,836,388 ops/sec ±0.18% (195 runs sampled)
  parse support.google.com  x  7,260,207 ops/sec ±0.27% (197 runs sampled)
  parse www.google.com      x  4,770,988 ops/sec ±0.20% (197 runs sampled)
  parse youtu.be            x  2,229,027 ops/sec ±0.24% (196 runs sampled)
  parse youtube.com         x  2,234,865 ops/sec ±0.22% (196 runs sampled)

> /Users/blakeembrey/.n/bin/node benchmark/parse.js

  cookie.parse - generic

  6 tests completed.

  simple      x 15,129,601 ops/sec ±0.33% (193 runs sampled)
  decode      x  5,200,520 ops/sec ±0.33% (197 runs sampled)
  unquote     x 14,504,769 ops/sec ±0.32% (197 runs sampled)
  duplicates  x  4,088,642 ops/sec ±0.29% (195 runs sampled)
  10 cookies  x  1,182,534 ops/sec ±0.25% (194 runs sampled)
  100 cookies x     82,411 ops/sec ±0.55% (196 runs sampled)
```