### PR TITLE
Remove quote parsing from package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,14 +124,6 @@ export function parse(
       let valStartIdx = startIndex(str, eqIdx + 1, endIdx);
       let valEndIdx = endIndex(str, endIdx, valStartIdx);
 
-      if (
-        str.charCodeAt(valStartIdx) === 0x22 /* " */ &&
-        str.charCodeAt(valEndIdx - 1) === 0x22 /* " */
-      ) {
-        valStartIdx++;
-        valEndIdx--;
-      }
-
       const value = dec(str.slice(valStartIdx, valEndIdx));
       obj[key] = value;
     }

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -25,24 +25,19 @@ describe("cookie.parse(str)", function () {
 
   it("should URL-decode values", function () {
     expect(cookie.parse('foo="bar=123456789&name=Magic+Mouse"')).toEqual({
-      foo: "bar=123456789&name=Magic+Mouse",
+      foo: '"bar=123456789&name=Magic+Mouse"',
     });
 
     expect(cookie.parse("email=%20%22%2c%3b%2f")).toEqual({ email: ' ",;/' });
   });
 
-  it("should parse quoted values", function () {
-    expect(cookie.parse('foo="bar"')).toEqual({ foo: "bar" });
-    expect(cookie.parse('foo=" a b c "')).toEqual({ foo: " a b c " });
-  });
-
   it("should trim whitespace around key and value", function () {
-    expect(cookie.parse('  foo  =  "bar"  ')).toEqual({ foo: "bar" });
+    expect(cookie.parse('  foo  =  "bar"  ')).toEqual({ foo: '"bar"' });
     expect(cookie.parse("  foo  =  bar  ;  fizz  =  buzz  ")).toEqual({
       foo: "bar",
       fizz: "buzz",
     });
-    expect(cookie.parse(' foo = " a b c " ')).toEqual({ foo: " a b c " });
+    expect(cookie.parse(' foo = " a b c " ')).toEqual({ foo: '" a b c "' });
     expect(cookie.parse(" = bar ")).toEqual({ "": "bar" });
     expect(cookie.parse(" foo = ")).toEqual({ foo: "" });
     expect(cookie.parse("   =   ")).toEqual({ "": "" });


### PR DESCRIPTION
Another RFC (cc @gurgunday). Removes a single check that wouldn't be relevant if this package set the cookie to begin with. Clients do not surreptitiously add quotes to cookies (as far as I know?), it's just a cookie value is valid to be surrounded by quotes.