### PR TITLE
remove hasOwnProperty call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,8 +93,8 @@ export interface ParseOptions {
 export function parse(
   str: string,
   options?: ParseOptions,
-): Record<string, string> {
-  const obj: Record<string, string> = new NullObject();
+): Record<string, string | undefined> {
+  const obj: Record<string, string | undefined> = new NullObject();
   const len = str.length;
   // RFC 6265 sec 4.1.1, RFC 2616 2.2 defines a cookie name consists of one char minimum, plus '='.
   if (len < 2) return obj;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,6 @@ const domainValueRegExp =
 const pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
 
 const __toString = Object.prototype.toString;
-const __hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const NullObject = /* @__PURE__ */ (() => {
   const C = function () {};
@@ -121,7 +120,7 @@ export function parse(
     const key = str.slice(keyStartIdx, keyEndIdx);
 
     // only assign once
-    if (!__hasOwnProperty.call(obj, key)) {
+    if (obj[key] === undefined) {
       let valStartIdx = startIndex(str, eqIdx + 1, endIdx);
       let valEndIdx = endIndex(str, endIdx, valStartIdx);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export interface ParseOptions {
    *
    * @default decodeURIComponent
    */
-  decode?: (str: string) => string | undefined;
+  decode?: (str: string) => string;
 }
 
 /**
@@ -133,7 +133,8 @@ export function parse(
       }
 
       const value = dec(str.slice(valStartIdx, valEndIdx));
-      if (value !== undefined) obj[key] = value;
+
+      obj[key] = value;
     }
 
     index = endIdx + 1;
@@ -365,7 +366,7 @@ export function serialize(
 /**
  * URL-decode string value. Optimized to skip native call when no %.
  */
-function decode(str: string): string | undefined {
+function decode(str: string): string {
   if (str.indexOf("%") === -1) return str;
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export interface ParseOptions {
    *
    * @default decodeURIComponent
    */
-  decode?: (str: string) => string;
+  decode?: (str: string) => string | undefined;
 }
 
 /**
@@ -133,7 +133,6 @@ export function parse(
       }
 
       const value = dec(str.slice(valStartIdx, valEndIdx));
-
       obj[key] = value;
     }
 


### PR DESCRIPTION
Since the object no longer has a prototype chain, we can just check if a key exists by accessing it