### PR TITLE
fix: case sensitive header options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -308,7 +308,11 @@ export function serialize(
   }
 
   if (options.priority) {
-    switch (options.priority) {
+    const priority =
+      typeof options.priority === "string"
+        ? options.priority.toLowerCase()
+        : options.sameSite;
+    switch (priority) {
       case "low":
         str += "; Priority=Low";
         break;
@@ -324,7 +328,11 @@ export function serialize(
   }
 
   if (options.sameSite) {
-    switch (options.sameSite) {
+    const sameSite =
+      typeof options.sameSite === "string"
+        ? options.sameSite.toLowerCase()
+        : options.sameSite;
+    switch (sameSite) {
       case true:
       case "strict":
         str += "; SameSite=Strict";

--- a/src/serialize.spec.ts
+++ b/src/serialize.spec.ts
@@ -282,6 +282,13 @@ describe("cookie.serialize(name, value, options)", function () {
         "foo=bar; Priority=High",
       );
     });
+
+    it("should set priority case insensitive", function () {
+      /** @ts-expect-error */
+      expect(cookie.serialize("foo", "bar", { priority: "High" })).toEqual(
+        "foo=bar; Priority=High",
+      );
+    });
   });
 
   describe('with "sameSite" option', function () {
@@ -318,6 +325,13 @@ describe("cookie.serialize(name, value, options)", function () {
     it("should not set sameSite when false", function () {
       expect(cookie.serialize("foo", "bar", { sameSite: false })).toEqual(
         "foo=bar",
+      );
+    });
+
+    it("should set sameSite case insensitive", function () {
+      /** @ts-expect-error */
+      expect(cookie.serialize("foo", "bar", { sameSite: "Lax" })).toEqual(
+        "foo=bar; SameSite=Lax",
       );
     });
   });


### PR DESCRIPTION
Basically copies the logic from latest "0" release. Not 100% sure with the `/** @ts-expect-error */` part in the tests, but I think it makes the most sense.

context => https://github.com/jshttp/cookie/blob/v0.7.2/index.js#L254-L255

fixes: #193 