### PR TITLE
Fix codecov workflow in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
     name: Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     strategy:
       matrix:
@@ -27,4 +26,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           name: Node.js ${{ matrix.node-version }}
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The codecov behavior of OIDC was broken in https://github.com/codecov/codecov-action/issues/1594, and I was hoping it'd get fixed upstream, but the experience of it failing is bad enough to fix it by switching to tokens instead. This works because forks don't need a token 🤷 