### PR TITLE
Add stringify method to mirror parse

### DIFF
--- a/src/stringify.spec.ts
+++ b/src/stringify.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { stringify } from "./index.js";
+
+describe("stringify", () => {
+  it("should stringify object", () => {
+    expect(stringify({ key: "value" })).toEqual("key=value");
+  });
+
+  it("should stringify objects with multiple entries", () => {
+    expect(stringify({ a: "1", b: "2" })).toEqual("a=1; b=2");
+  });
+
+  it("should ignore undefined values", () => {
+    expect(stringify({ a: "1", b: undefined })).toEqual("a=1");
+  });
+
+  it("should error on invalid keys", () => {
+    expect(() => stringify({ "test=": "" })).toThrow(/cookie name is invalid/);
+  });
+
+  it("should error on invalid values", () => {
+    expect(() => stringify({ test: ";" }, { encode: (x) => x })).toThrow(
+      /cookie val is invalid/,
+    );
+  });
+});


### PR DESCRIPTION
Part of the work from https://github.com/jshttp/cookie/issues/200, adding methods that mirror the existing methods so someone can easily understand `parse`/`stringify` and (in another PR) `serialize`/`deserialize`.