### PR TITLE
Fix TS inconsistency (parse method never returns undefined).

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export interface ParseOptions {
    *
    * @default decode
    */
-  decode?: (str: string) => string | undefined;
+  decode?: (str: string) => string;
 }
 
 /**
@@ -98,8 +98,8 @@ export interface ParseOptions {
 export function parse(
   str: string,
   options?: ParseOptions,
-): Record<string, string | undefined> {
-  const obj: Record<string, string | undefined> = new NullObject();
+): Record<string, string> {
+  const obj: Record<string, string> = new NullObject();
   const len = str.length;
   // RFC 6265 sec 4.1.1, RFC 2616 2.2 defines a cookie name consists of one char minimum, plus '='.
   if (len < 2) return obj;


### PR DESCRIPTION
In this PR: #179, `undefined` was added to the type definition and code, then the code was refactored but the type definition was not updated. See the review here: https://github.com/jshttp/cookie/pull/179#discussion_r1791199926 to understand the history.