### PR TITLE
Overwrite value in passed in options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -293,7 +293,7 @@ export function stringifySetCookie(
   const cookie =
     typeof _name === "object"
       ? _name
-      : { name: _name, value: String(_val), ..._opts };
+      : { ..._opts, name: _name, value: String(_val) };
   const options = typeof _val === "object" ? _val : _opts;
   const enc = options?.encode || encodeURIComponent;
 

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -35,6 +35,12 @@ describe("cookie.stringifySetCookie", function () {
     ).toEqual("foo=bar+baz");
   });
 
+  it("should support three argument mode with value in options", function () {
+    expect(
+      cookie.stringifySetCookie("foo", "test", { value: "ignored" } as any),
+    ).toEqual("foo=test");
+  });
+
   it.each([
     ["foo"],
     ["foo,bar"],


### PR DESCRIPTION
From X, a user reported a regression and it looks like an unfortunate conflict in property names due to `options` backward-compatibility. 

Issue in code: https://github.com/elysiajs/elysia/blob/5eec011e53784445dc9d63635aeccb4f4d5d5c3e/src/cookies.ts#L445-L453

Caused by `value` being passed as an argument and also in `options`, and `options` took priority instead of the expected `value`.