### PR TITLE
perf: add early exit in valueSlice for empty ranges

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -500,6 +500,7 @@ function eqIndex(str: string, min: number, max: number) {
  * Slice out a value between startPod to max.
  */
 function valueSlice(str: string, min: number, max: number) {
+  if (min >= max) return "";
   let start = min;
   let end = max;
 


### PR DESCRIPTION
add early return when min >= max to avoid unnecessary processing for empty string ranges.
This handles edge cases like empty cookie values, empty string inputs, empty attribute values, and consecutive semicolons.
This optimization avoids character code checks and loop iterations when the slice range is empty or invalid.