### PR TITLE
refactor: use includes() instead of indexOf() for boolean checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -521,7 +521,7 @@ function valueSlice(str: string, min: number, max: number) {
  * URL-decode string value. Optimized to skip native call when no %.
  */
 function decode(str: string): string {
-  if (str.indexOf("%") === -1) return str;
+  if (!str.includes("%")) return str;
 
   try {
     return decodeURIComponent(str);


### PR DESCRIPTION
Replace str.indexOf("%") === -1 with !str.includes("%") in decode function. This improves readability and may have slight performance benefits as includes() is optimized for boolean checks in modern JavaScript engines.