### PR TITLE
Faster stringify cookie with benchmarks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,9 +158,11 @@ export function stringifyCookie(
   options?: StringifyOptions,
 ): string {
   const enc = options?.encode || encodeURIComponent;
-  const cookieStrings: string[] = [];
+  const keys = Object.keys(cookie);
+  let str = "";
 
-  for (const name of Object.keys(cookie)) {
+  for (let i = 0; i < keys.length; i++) {
+    const name = keys[i];
     const val = cookie[name];
     if (val === undefined) continue;
 
@@ -174,10 +176,11 @@ export function stringifyCookie(
       throw new TypeError(`cookie val is invalid: ${val}`);
     }
 
-    cookieStrings.push(`${name}=${value}`);
+    if (i > 0) str += "; ";
+    str += name + "=" + value;
   }
 
-  return cookieStrings.join("; ");
+  return str;
 }
 
 /**

--- a/src/stringify-cookie.bench.ts
+++ b/src/stringify-cookie.bench.ts
@@ -1,0 +1,41 @@
+import { describe, bench } from "vitest";
+import * as cookie from "./index.js";
+
+describe("cookie.stringifyCookie", () => {
+  bench("empty", () => {
+    cookie.stringifyCookie({});
+  });
+
+  bench("simple", () => {
+    cookie.stringifyCookie({ foo: "bar" });
+  });
+
+  bench("undefined values", () => {
+    cookie.stringifyCookie({
+      foo: "bar",
+      baz: undefined,
+      qux: "quux",
+      zap: undefined,
+    });
+  });
+
+  const cookies10 = genCookies(10);
+  bench("10 cookies", () => {
+    cookie.stringifyCookie(cookies10);
+  });
+
+  const cookies100 = genCookies(100);
+  bench("100 cookies", () => {
+    cookie.stringifyCookie(cookies100);
+  });
+});
+
+function genCookies(num: number) {
+  const cookies: Record<string, string | undefined> = {};
+
+  for (let i = 0; i < num; i++) {
+    cookies["foo" + i] = "bar" + i;
+  }
+
+  return cookies;
+}

--- a/src/stringify-set-cookie.bench.ts
+++ b/src/stringify-set-cookie.bench.ts
@@ -1,0 +1,71 @@
+import { describe, bench } from "vitest";
+import * as cookie from "./index.js";
+
+describe("cookie.stringifySetCookie", () => {
+  bench("simple", () => {
+    cookie.stringifySetCookie("foo", "bar");
+  });
+
+  bench("encode", () => {
+    cookie.stringifySetCookie("foo", "hello there!");
+  });
+
+  const expires = new Date("Wed, 21 Oct 2015 07:28:00 GMT");
+  bench("attributes", () => {
+    cookie.stringifySetCookie("foo", "bar", {
+      path: "/",
+      domain: "example.com",
+      maxAge: 3600,
+      expires,
+      httpOnly: true,
+      secure: true,
+      partitioned: true,
+      priority: "high",
+      sameSite: "lax",
+    });
+  });
+
+  bench("object input", () => {
+    cookie.stringifySetCookie({
+      name: "foo",
+      value: "bar",
+      path: "/",
+      maxAge: 3600,
+      httpOnly: true,
+      secure: true,
+      sameSite: "strict",
+    });
+  });
+
+  const setCookies10 = genSetCookies(10);
+  bench("10 set-cookies", () => {
+    for (const setCookie of setCookies10) {
+      cookie.stringifySetCookie(setCookie);
+    }
+  });
+
+  const setCookies100 = genSetCookies(100);
+  bench("100 set-cookies", () => {
+    for (const setCookie of setCookies100) {
+      cookie.stringifySetCookie(setCookie);
+    }
+  });
+});
+
+function genSetCookies(num: number): cookie.SetCookie[] {
+  const cookies: cookie.SetCookie[] = [];
+
+  for (let i = 0; i < num; i++) {
+    cookies.push({
+      name: "foo" + i,
+      value: "bar " + i,
+      path: "/foo" + i,
+      maxAge: 3600,
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+    });
+  }
+
+  return cookies;
+}


### PR DESCRIPTION
I decided to try investigating if anything in https://github.com/jshttp/cookie/issues/250 holds true, and found the opposite for string concatenation. Updated to use string concatenation to improve performance.

Before: 

```
 ✓ src/stringify-cookie.bench.ts > cookie.stringifyCookie 7195ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · empty             19,138,902.74  0.0000  0.0572  0.0001  0.0000  0.0001  0.0001  0.0002  ±0.11%  9569452
   · simple             5,777,350.07  0.0001  0.3515  0.0002  0.0002  0.0002  0.0003  0.0006  ±0.39%  2888676
   · undefined values   3,129,664.63  0.0002  0.3241  0.0003  0.0003  0.0004  0.0004  0.0008  ±0.46%  1564833
   · 10 cookies           765,737.48  0.0012  0.4257  0.0013  0.0013  0.0014  0.0016  0.0020  ±0.34%   382869
   · 100 cookies           78,240.71  0.0122  0.4788  0.0128  0.0128  0.0137  0.0160  0.0424  ±0.39%    39121
```

After:

```
 ✓ src/stringify-cookie.bench.ts > cookie.stringifyCookie 7958ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme   samples
   · empty             21,654,747.61  0.0000  0.1649  0.0000  0.0000  0.0001  0.0001  0.0002  ±0.14%  10827374
   · simple             7,345,985.72  0.0000  0.0540  0.0001  0.0001  0.0002  0.0002  0.0003  ±0.10%   3672994
   · undefined values   3,820,139.53  0.0002  0.0491  0.0003  0.0003  0.0003  0.0004  0.0004  ±0.11%   1910070
   · 10 cookies           854,240.43  0.0010  0.4322  0.0012  0.0012  0.0013  0.0014  0.0019  ±0.44%    427121
   · 100 cookies           85,417.71  0.0110  0.4168  0.0117  0.0117  0.0126  0.0160  0.0470  ±0.44%     42709
```