### PR TITLE
test: expand stringifyCookie coverage and add roundtrip tests

### DIFF
--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stringifyCookie } from "./index.js";
+import { stringifyCookie, parseCookie } from "./index.js";
 
 describe("cookie.stringifyCookie", () => {
   it("should stringify object", () => {
@@ -14,15 +14,123 @@ describe("cookie.stringifyCookie", () => {
     expect(stringifyCookie({ a: "1", b: undefined })).toEqual("a=1");
   });
 
+  it("should return empty string for empty object", () => {
+    expect(stringifyCookie({})).toEqual("");
+  });
+
+  it("should return empty string when all values are undefined", () => {
+    expect(stringifyCookie({ a: undefined, b: undefined })).toEqual("");
+  });
+
+  it("should stringify empty string values", () => {
+    expect(stringifyCookie({ a: "" })).toEqual("a=");
+    expect(stringifyCookie({ a: "", b: "" })).toEqual("a=; b=");
+  });
+
+  it("should URL-encode values by default", () => {
+    expect(stringifyCookie({ foo: "bar baz" })).toEqual("foo=bar%20baz");
+    expect(stringifyCookie({ foo: "a=b" })).toEqual("foo=a%3Db");
+    expect(stringifyCookie({ foo: "hello;world" })).toEqual(
+      "foo=hello%3Bworld",
+    );
+  });
+
   it("should error on invalid keys", () => {
     expect(() => stringifyCookie({ "test=": "" })).toThrow(
       /cookie name is invalid/,
     );
   });
 
+  it.each([["foo bar"], ["foo;bar"], ["foo\tbar"], ["foo\nbar"]])(
+    "should throw for invalid name: %s",
+    (name) => {
+      expect(() => stringifyCookie({ [name]: "val" })).toThrow(
+        /cookie name is invalid/,
+      );
+    },
+  );
+
   it("should error on invalid values", () => {
     expect(() => stringifyCookie({ test: ";" }, { encode: (x) => x })).toThrow(
       /cookie val is invalid/,
     );
+  });
+
+  it.each([
+    ["foo!bar"],
+    ["foo#bar"],
+    ["foo$bar"],
+    ["foo&bar"],
+    ["foo*bar"],
+    ["foo+bar"],
+    ["foo-bar"],
+    ["foo.bar"],
+    ["foo^bar"],
+    ["foo_bar"],
+    ["foo`bar"],
+    ["foo|bar"],
+    ["foo~bar"],
+    ["foo7bar"],
+  ])("should accept valid cookie name: %s", (name) => {
+    expect(stringifyCookie({ [name]: "val" })).toEqual(`${name}=val`);
+  });
+
+  describe('with "encode" option', () => {
+    it("should use custom encode function", () => {
+      expect(
+        stringifyCookie(
+          { foo: "bar" },
+          {
+            encode: (v) => Buffer.from(v, "utf8").toString("base64"),
+          },
+        ),
+      ).toEqual("foo=YmFy");
+    });
+
+    it("should pass through values with identity encoder", () => {
+      expect(stringifyCookie({ foo: "bar" }, { encode: (x) => x })).toEqual(
+        "foo=bar",
+      );
+    });
+
+    it("should throw when custom encoder produces invalid value", () => {
+      expect(() =>
+        stringifyCookie({ foo: "bar" }, { encode: () => "invalid value" }),
+      ).toThrow(/cookie val is invalid/);
+    });
+  });
+
+  describe("roundtrip with parseCookie", () => {
+    it("should roundtrip simple values", () => {
+      const cookies = { foo: "bar", baz: "qux" };
+      const str = stringifyCookie(cookies);
+      expect(parseCookie(str)).toEqual(cookies);
+    });
+
+    it("should roundtrip URL-encoded values", () => {
+      const cookies = { session: "abc 123", token: "x=y&z" };
+      const str = stringifyCookie(cookies);
+      expect(parseCookie(str)).toEqual(cookies);
+    });
+
+    it("should roundtrip empty values", () => {
+      const cookies = { a: "", b: "value" };
+      const str = stringifyCookie(cookies);
+      expect(parseCookie(str)).toEqual(cookies);
+    });
+
+    it("should roundtrip single cookie", () => {
+      const cookies = { session_id: "abc123def456" };
+      const str = stringifyCookie(cookies);
+      expect(parseCookie(str)).toEqual(cookies);
+    });
+
+    it("should roundtrip with custom encode/decode", () => {
+      const encode = (v: string) => Buffer.from(v, "utf8").toString("base64");
+      const decode = (v: string) => Buffer.from(v, "base64").toString("utf8");
+      const cookies = { data: "hello world" };
+      const str = stringifyCookie(cookies, { encode });
+      expect(parseCookie(str, { decode })).toEqual(cookies);
+    });
   });
 });


### PR DESCRIPTION
## What

Expanded test coverage for `stringifyCookie` from 5 tests to 35 tests, and added roundtrip tests between `parseCookie` and `stringifyCookie`.

## Why

The `stringifyCookie` function had minimal test coverage compared to the other functions in the library. While `parseCookie` has 27 tests and `stringifySetCookie` has 94 tests, `stringifyCookie` only had 5 basic tests. I noticed this gap while working with the cookie package in my Express session middleware — wanted to make sure the stringify/parse cycle is well-tested.

## New tests added

**Basic behavior:**
- Empty object returns empty string
- All-undefined values returns empty string
- Empty string values serialized correctly

**Encoding:**
- Default URL encoding of spaces, equals, semicolons
- Custom encode function (base64 example)
- Identity encoder pass-through
- Throws when custom encoder produces invalid cookie value

**Validation:**
- Valid cookie names (special characters: `!`, `#`, `$`, `&`, `*`, `+`, `-`, `.`, `^`, `_`, `` ` ``, `|`, `~`)
- Invalid cookie names (spaces, semicolons, tabs, newlines)

**Roundtrip (parseCookie ↔ stringifyCookie):**
- Simple key-value pairs
- URL-encoded values with spaces and special characters
- Empty values
- Single cookie
- Custom encode/decode pair (base64)

## Testing

```bash
npx vitest run
# Test Files  4 passed (4)
#      Tests  228 passed (228)
```

All existing tests continue to pass. Formatting verified with `npm run format`.