### PR TITLE
Fix leading semicolon when stringifying cookies with skipped values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export function stringifyCookie(
       throw new TypeError(`cookie val is invalid: ${val}`);
     }
 
-    if (i > 0) str += "; ";
+    if (str) str += "; ";
     str += name + "=" + value;
   }
 

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -12,6 +12,7 @@ describe("cookie.stringifyCookie", () => {
 
   it("should ignore undefined values", () => {
     expect(stringifyCookie({ a: "1", b: undefined })).toEqual("a=1");
+    expect(stringifyCookie({ a: undefined, b: "2" })).toEqual("b=2");
   });
 
   it("should error on invalid keys", () => {


### PR DESCRIPTION
Fixes `stringifyCookie` output when the first cookie entry has an `undefined` value.

Previously, separators were based on the loop index. If the first key was skipped, the next emitted cookie still got a leading `; `:

```ts
stringifyCookie({ a: undefined, b: "2" })
// before: "; b=2"
// after: "b=2"
```

This changes separator insertion to check whether output has already been written.

Test added for the skipped-first-entry case.

Validation:
- `npm run specs -- src/stringify-cookie.spec.ts`
- `npm test`