### PR TITLE
perf: make stringifySetCookie 37% faster for Node18/Node20

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -293,24 +293,25 @@ export function stringifySetCookie(
   _val?: string | StringifyOptions,
   _opts?: SerializeOptions,
 ): string {
-  const cookie =
-    typeof _name === "object"
-      ? _name
-      : { ..._opts, name: _name, value: String(_val) };
+  const cookie = typeof _name === "object" ? _name : _opts;
+  const name = typeof _name === "object" ? _name.name : _name;
+  const rawValue = typeof _name === "object" ? _name.value : String(_val);
   const options = typeof _val === "object" ? _val : _opts;
   const enc = options?.encode || encodeURIComponent;
 
-  if (!cookieNameRegExp.test(cookie.name)) {
-    throw new TypeError(`argument name is invalid: ${cookie.name}`);
+  if (!cookieNameRegExp.test(name)) {
+    throw new TypeError(`argument name is invalid: ${name}`);
   }
 
-  const value = cookie.value ? enc(cookie.value) : "";
+  const value = rawValue ? enc(rawValue) : "";
 
   if (!cookieValueRegExp.test(value)) {
-    throw new TypeError(`argument val is invalid: ${cookie.value}`);
+    throw new TypeError(`argument val is invalid: ${rawValue}`);
   }
 
-  let str = cookie.name + "=" + value;
+  let str = name + "=" + value;
+
+  if (!cookie) return str;
 
   if (cookie.maxAge !== undefined) {
     if (!Number.isInteger(cookie.maxAge)) {


### PR DESCRIPTION
Avoid creating a temporary cookie object for the `stringifySetCookie(name, value, options)` overload.

Previously this path copied options into a new object:

```ts
{ ..._opts, name: _name, value: String(_val) }
```

The function then immediately read those values back. This change reads `name`, `value`, and options directly, avoiding the object spread and extra allocation.

The no-options `simple` case stayed roughly flat in local runs. The main win is for option-heavy and repeated `Set-Cookie` serialization.

Benchmark:

`npm run bench -- src/stringify-set-cookie.bench.ts`

| Case | Before ops/sec | After ops/sec | Improvement |
|---|---:|---:|---:|
| attributes | 557,937.36 | 2,434,022.10 | +336.25% |
| 10 set-cookies | 573,730.84 | 782,330.30 | +36.36% |
| 100 set-cookies | 56,280.08 | 77,878.66 | +38.38% |

Validation:

- `npm test`
- `npm run bench -- src/stringify-set-cookie.bench.ts`