### PR TITLE
Optimize stringifyCookie by 2x for cookie-octet values

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const cookieHeader = cookie.stringifyCookie({ a: "foo", b: "bar" });
 
 #### Options
 
-- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving roundtrip-safe cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
+- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`encodeURIComponent`](#encode-and-decode).
 
 ### cookie.parseSetCookie(str, options)
 
@@ -88,7 +88,7 @@ const setCookieHeader = cookie.stringifySetCookie({
 
 #### Options
 
-- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving roundtrip-safe cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
+- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`encodeURIComponent`](#encode-and-decode).
 
 ## Cookie object
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const cookieHeader = cookie.stringifyCookie({ a: "foo", b: "bar" });
 
 #### Options
 
-- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving valid cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
+- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving roundtrip-safe cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
 
 ### cookie.parseSetCookie(str, options)
 
@@ -88,7 +88,7 @@ const setCookieHeader = cookie.stringifySetCookie({
 
 #### Options
 
-- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving valid cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
+- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving roundtrip-safe cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
 
 ## Cookie object
 
@@ -178,7 +178,7 @@ More information about enforcement levels can be found in [the specification](ht
 Cookie accepts `encode` or `decode` options for processing a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1).
 Since the value of a cookie has a limited character set (and must be a simple string), these functions are used to transform values into strings suitable for a cookies value.
 
-The default `encode` function preserves valid RFC 6265 cookie-octet values and uses the global `encodeURIComponent` otherwise.
+The default `encode` function preserves roundtrip-safe cookie-octet values and uses the global `encodeURIComponent` otherwise.
 
 The default `decode` function is the global `decodeURIComponent`, wrapped in a `try..catch`. If an error
 is thrown it will return the cookie's original value. If you provide your own encode/decode

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const cookieHeader = cookie.stringifyCookie({ a: "foo", b: "bar" });
 
 #### Options
 
-- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`encodeURIComponent`](#encode-and-decode).
+- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving valid cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
 
 ### cookie.parseSetCookie(str, options)
 
@@ -88,7 +88,7 @@ const setCookieHeader = cookie.stringifySetCookie({
 
 #### Options
 
-- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`encodeURIComponent`](#encode-and-decode).
+- `encode` Specifies the function to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to preserving valid cookie-octet values and using [`encodeURIComponent`](#encode-and-decode) otherwise.
 
 ## Cookie object
 
@@ -178,7 +178,7 @@ More information about enforcement levels can be found in [the specification](ht
 Cookie accepts `encode` or `decode` options for processing a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1).
 Since the value of a cookie has a limited character set (and must be a simple string), these functions are used to transform values into strings suitable for a cookies value.
 
-The default `encode` function is the global `encodeURIComponent`.
+The default `encode` function preserves valid RFC 6265 cookie-octet values and uses the global `encodeURIComponent` otherwise.
 
 The default `decode` function is the global `decodeURIComponent`, wrapped in a `try..catch`. If an error
 is thrown it will return the cookie's original value. If you provide your own encode/decode

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ const pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
 const maxAgeRegExp = /^-?\d+$/;
 
 /**
- * RegExp to match RFC 6265 cookie-octet values (without % to preserve round-trip) that need no URL encoding.
+ * RegExp to match RFC 6265 cookie-octet values (without % to preserve roundtrip) that need no URL encoding.
  */
 const cookieOctetRegExp = /^[!#$&'()*+\-.\/0-9:<=>?@A-Z[\]\^_`a-z{|}~]*$/;
 
@@ -150,8 +150,6 @@ export interface StringifyOptions {
    * Since value of a cookie has a limited character set (and must be a simple string), this function can be used to encode
    * a value into a string suited for a cookie's value, and should mirror `decode` when parsing.
    * The default function preserves roundtrip-safe cookie-octet values and uses `encodeURIComponent` otherwise.
-   *
-   * @default encode
    */
   encode?: (str: string) => string;
 }
@@ -163,7 +161,7 @@ export function stringifyCookie(
   cookie: Cookies,
   options?: StringifyOptions,
 ): string {
-  const enc = options?.encode || encode;
+  const enc = options?.encode || defaultEncode;
   const keys = Object.keys(cookie);
   let str = "";
 
@@ -304,7 +302,7 @@ export function stringifySetCookie(
       ? _name
       : { ..._opts, name: _name, value: String(_val) };
   const options = typeof _val === "object" ? _val : _opts;
-  const enc = options?.encode || encode;
+  const enc = options?.encode || defaultEncode;
 
   if (!cookieNameRegExp.test(cookie.name)) {
     throw new TypeError(`argument name is invalid: ${cookie.name}`);
@@ -543,7 +541,7 @@ function decode(str: string): string {
 /**
  * URL-encode string value. Optimized to skip native call for roundtrip-safe cookie-octet values.
  */
-function encode(str: string): string {
+function defaultEncode(str: string): string {
   return cookieOctetRegExp.test(str) ? str : encodeURIComponent(str);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,10 @@ const pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
  */
 const maxAgeRegExp = /^-?\d+$/;
 
-const noEncodeRegExp = /^[\w.!~*'()-]*$/;
+/**
+ * RegExp to match RFC 6265 cookie-octet values that need no URL encoding.
+ */
+const cookieOctetRegExp = /^[!#$%&'()*+\-.\/0-9:<=>?@A-Z[\]\^_`a-z{|}~]*$/;
 
 const __toString = Object.prototype.toString;
 
@@ -146,8 +149,9 @@ export interface StringifyOptions {
    * Specifies a function that will be used to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1).
    * Since value of a cookie has a limited character set (and must be a simple string), this function can be used to encode
    * a value into a string suited for a cookie's value, and should mirror `decode` when parsing.
+   * The default function preserves valid RFC 6265 cookie-octet values and uses `encodeURIComponent` otherwise.
    *
-   * @default encodeURIComponent
+   * @default encode
    */
   encode?: (str: string) => string;
 }
@@ -300,7 +304,7 @@ export function stringifySetCookie(
       ? _name
       : { ..._opts, name: _name, value: String(_val) };
   const options = typeof _val === "object" ? _val : _opts;
-  const enc = options?.encode || encodeURIComponent;
+  const enc = options?.encode || encode;
 
   if (!cookieNameRegExp.test(cookie.name)) {
     throw new TypeError(`argument name is invalid: ${cookie.name}`);
@@ -537,10 +541,10 @@ function decode(str: string): string {
 }
 
 /**
- * URL-encode string value. Optimized to skip native call when no escaping is needed.
+ * URL-encode string value. Optimized to skip native call for RFC 6265 cookie-octet values.
  */
 function encode(str: string): string {
-  return noEncodeRegExp.test(str) ? str : encodeURIComponent(str);
+  return cookieOctetRegExp.test(str) ? str : encodeURIComponent(str);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,9 +69,9 @@ const pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
 const maxAgeRegExp = /^-?\d+$/;
 
 /**
- * RegExp to match RFC 6265 cookie-octet values that need no URL encoding.
+ * RegExp to match RFC 6265 cookie-octet values (without % to preserve round-trip) that need no URL encoding.
  */
-const cookieOctetRegExp = /^[!#$%&'()*+\-.\/0-9:<=>?@A-Z[\]\^_`a-z{|}~]*$/;
+const cookieOctetRegExp = /^[!#$&'()*+\-.\/0-9:<=>?@A-Z[\]\^_`a-z{|}~]*$/;
 
 const __toString = Object.prototype.toString;
 
@@ -149,7 +149,7 @@ export interface StringifyOptions {
    * Specifies a function that will be used to encode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1).
    * Since value of a cookie has a limited character set (and must be a simple string), this function can be used to encode
    * a value into a string suited for a cookie's value, and should mirror `decode` when parsing.
-   * The default function preserves valid RFC 6265 cookie-octet values and uses `encodeURIComponent` otherwise.
+   * The default function preserves roundtrip-safe cookie-octet values and uses `encodeURIComponent` otherwise.
    *
    * @default encode
    */
@@ -541,7 +541,7 @@ function decode(str: string): string {
 }
 
 /**
- * URL-encode string value. Optimized to skip native call for RFC 6265 cookie-octet values.
+ * URL-encode string value. Optimized to skip native call for roundtrip-safe cookie-octet values.
  */
 function encode(str: string): string {
   return cookieOctetRegExp.test(str) ? str : encodeURIComponent(str);

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,8 @@ const pathValueRegExp = /^[\u0020-\u003A\u003D-\u007E]*$/;
  */
 const maxAgeRegExp = /^-?\d+$/;
 
+const noEncodeRegExp = /^[\w.!~*'()-]*$/;
+
 const __toString = Object.prototype.toString;
 
 const NullObject = /* @__PURE__ */ (() => {
@@ -157,7 +159,7 @@ export function stringifyCookie(
   cookie: Cookies,
   options?: StringifyOptions,
 ): string {
-  const enc = options?.encode || encodeURIComponent;
+  const enc = options?.encode || encode;
   const keys = Object.keys(cookie);
   let str = "";
 
@@ -532,6 +534,13 @@ function decode(str: string): string {
   } catch (e) {
     return str;
   }
+}
+
+/**
+ * URL-encode string value. Optimized to skip native call when no escaping is needed.
+ */
+function encode(str: string): string {
+  return noEncodeRegExp.test(str) ? str : encodeURIComponent(str);
 }
 
 /**

--- a/src/stringify-cookie.bench.ts
+++ b/src/stringify-cookie.bench.ts
@@ -10,12 +10,24 @@ describe("cookie.stringifyCookie", () => {
     cookie.stringifyCookie({ foo: "bar" });
   });
 
+  bench("encode", () => {
+    cookie.stringifyCookie({ foo: "bar baz;%" });
+  });
+
   bench("undefined values", () => {
     cookie.stringifyCookie({
       foo: "bar",
       baz: undefined,
       qux: "quux",
       zap: undefined,
+    });
+  });
+
+  bench("mixed encode", () => {
+    cookie.stringifyCookie({
+      foo: "bar",
+      baz: "quux zap",
+      qux: "quux",
     });
   });
 

--- a/src/stringify-cookie.bench.ts
+++ b/src/stringify-cookie.bench.ts
@@ -11,7 +11,7 @@ describe("cookie.stringifyCookie", () => {
   });
 
   bench("rfc cookie-octets", () => {
-    cookie.stringifyCookie({ foo: "a=b+c/d?x%20" });
+    cookie.stringifyCookie({ foo: "a=b+c/d?x~" });
   });
 
   bench("encode", () => {

--- a/src/stringify-cookie.bench.ts
+++ b/src/stringify-cookie.bench.ts
@@ -10,6 +10,10 @@ describe("cookie.stringifyCookie", () => {
     cookie.stringifyCookie({ foo: "bar" });
   });
 
+  bench("rfc cookie-octets", () => {
+    cookie.stringifyCookie({ foo: "a=b+c/d?x%20" });
+  });
+
   bench("encode", () => {
     cookie.stringifyCookie({ foo: "bar baz;%" });
   });

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -1,6 +1,38 @@
 import { describe, expect, it } from "vitest";
 import { stringifyCookie, parseCookie } from "./index.js";
 
+const roundtripSafeCookieOctets =
+  "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+  "^_`abcdefghijklmnopqrstuvwxyz{|}~";
+
+const defaultBmpEncodingCases: Array<[string, string, string]> = [];
+
+for (let code = 0; code <= 0xffff; code++) {
+  // encodeURIComponent throws on unpaired surrogates.
+  if (code >= 0xd800 && code <= 0xdfff) continue;
+
+  const value = String.fromCharCode(code);
+  const encoded = roundtripSafeCookieOctets.includes(value)
+    ? value
+    : encodeURIComponent(value);
+
+  defaultBmpEncodingCases.push([
+    `U+${code.toString(16).toUpperCase().padStart(4, "0")}`,
+    value,
+    `key=${encoded}`,
+  ]);
+}
+
+const defaultAstralEncodingCases: Array<[string, string, string]> = [];
+
+for (const value of ["😄", "𝌆", "𠜎"]) {
+  defaultAstralEncodingCases.push([
+    `U+${value.codePointAt(0)!.toString(16).toUpperCase()}`,
+    value,
+    `key=${encodeURIComponent(value)}`,
+  ]);
+}
+
 describe("cookie.stringifyCookie", () => {
   it("should stringify object", () => {
     expect(stringifyCookie({ key: "value" })).toEqual("key=value");
@@ -42,47 +74,24 @@ describe("cookie.stringifyCookie", () => {
   });
 
   it("should pass through roundtrip-safe cookie-octet values without encoding", () => {
-    const value =
-      "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
-      "^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    const value = roundtripSafeCookieOctets;
 
     expect(stringifyCookie({ foo: value })).toEqual(`foo=${value}`);
   });
 
-  it("should match default encoding for all valid BMP characters", () => {
-    const cookieOctets =
-      "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
-      "^_`abcdefghijklmnopqrstuvwxyz{|}~";
-    const mismatches: string[] = [];
+  it.each(defaultBmpEncodingCases)(
+    "should match default encoding for BMP char %s",
+    (_name, value, expected) => {
+      expect(stringifyCookie({ key: value })).toEqual(expected);
+    },
+  );
 
-    // Check every valid BMP character. Skip surrogate code units because
-    // encodeURIComponent throws on unpaired surrogates.
-    for (let code = 0; code <= 0xffff; code++) {
-      if (code >= 0xd800 && code <= 0xdfff) continue;
-
-      const value = String.fromCharCode(code);
-      const actual = stringifyCookie({ key: value });
-      const encoded = cookieOctets.includes(value)
-        ? value
-        : encodeURIComponent(value);
-      const expected = `key=${encoded}`;
-
-      if (actual !== expected) {
-        mismatches.push(`${code}: ${actual} !== ${expected}`);
-      }
-    }
-
-    for (const value of ["😄", "𝌆", "𠜎"]) {
-      const actual = stringifyCookie({ key: value });
-      const expected = `key=${encodeURIComponent(value)}`;
-
-      if (actual !== expected) {
-        mismatches.push(`${value}: ${actual} !== ${expected}`);
-      }
-    }
-
-    expect(mismatches).toEqual([]);
-  });
+  it.each(defaultAstralEncodingCases)(
+    "should match default encoding for astral char %s",
+    (_name, value, expected) => {
+      expect(stringifyCookie({ key: value })).toEqual(expected);
+    },
+  );
 
   it("should error on invalid keys", () => {
     expect(() => stringifyCookie({ "test=": "" })).toThrow(

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -28,15 +28,30 @@ describe("cookie.stringifyCookie", () => {
     expect(stringifyCookie({ a: "", b: "" })).toEqual("a=; b=");
   });
 
-  it("should URL-encode values by default", () => {
+  it("should encode values with non-cookie-octet chars by default", () => {
     expect(stringifyCookie({ foo: "bar baz" })).toEqual("foo=bar%20baz");
-    expect(stringifyCookie({ foo: "a=b" })).toEqual("foo=a%3Db");
     expect(stringifyCookie({ foo: "hello;world" })).toEqual(
       "foo=hello%3Bworld",
     );
+    expect(stringifyCookie({ foo: 'hello"world' })).toEqual(
+      "foo=hello%22world",
+    );
+    expect(stringifyCookie({ foo: "foo,bar" })).toEqual("foo=foo%2Cbar");
+    expect(stringifyCookie({ foo: "foo\\bar" })).toEqual("foo=foo%5Cbar");
   });
 
-  it("should match encodeURIComponent for default encoding", () => {
+  it("should pass through cookie-octet values by default", () => {
+    const value =
+      "!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+      "^_`abcdefghijklmnopqrstuvwxyz{|}~";
+
+    expect(stringifyCookie({ foo: value })).toEqual(`foo=${value}`);
+  });
+
+  it("should match cookie-octet default encoding", () => {
+    const cookieOctets =
+      "!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+      "^_`abcdefghijklmnopqrstuvwxyz{|}~";
     const mismatches: string[] = [];
 
     for (let code = 0; code <= 0xffff; code++) {
@@ -44,7 +59,10 @@ describe("cookie.stringifyCookie", () => {
 
       const value = String.fromCharCode(code);
       const actual = stringifyCookie({ key: value });
-      const expected = `key=${encodeURIComponent(value)}`;
+      const encoded = cookieOctets.includes(value)
+        ? value
+        : encodeURIComponent(value);
+      const expected = `key=${encoded}`;
 
       if (actual !== expected) {
         mismatches.push(`${code}: ${actual} !== ${expected}`);

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from "vitest";
 import { stringifyCookie, parseCookie } from "./index.js";
 
-const roundtripSafeCookieOctets =
+const cookieOctets =
   "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
   "^_`abcdefghijklmnopqrstuvwxyz{|}~";
 
-const defaultBmpEncodingCases: Array<[string, string, string]> = [];
+const bmpEncodingCases: Array<[string, string, string]> = [];
 
 for (let code = 0; code <= 0xffff; code++) {
   // encodeURIComponent throws on unpaired surrogates.
   if (code >= 0xd800 && code <= 0xdfff) continue;
 
   const value = String.fromCharCode(code);
-  const encoded = roundtripSafeCookieOctets.includes(value)
+  const encoded = cookieOctets.includes(value)
     ? value
     : encodeURIComponent(value);
 
-  defaultBmpEncodingCases.push([
+  bmpEncodingCases.push([
     `U+${code.toString(16).toUpperCase().padStart(4, "0")}`,
     value,
     `key=${encoded}`,
   ]);
 }
 
-const defaultAstralEncodingCases: Array<[string, string, string]> = [];
+const astralEncodingCases: Array<[string, string, string]> = [];
 
 for (const value of ["😄", "𝌆", "𠜎"]) {
-  defaultAstralEncodingCases.push([
+  astralEncodingCases.push([
     `U+${value.codePointAt(0)!.toString(16).toUpperCase()}`,
     value,
     `key=${encodeURIComponent(value)}`,
@@ -74,19 +74,19 @@ describe("cookie.stringifyCookie", () => {
   });
 
   it("should pass through roundtrip-safe cookie-octet values without encoding", () => {
-    const value = roundtripSafeCookieOctets;
+    const value = cookieOctets;
 
     expect(stringifyCookie({ foo: value })).toEqual(`foo=${value}`);
   });
 
-  it.each(defaultBmpEncodingCases)(
+  it.each(bmpEncodingCases)(
     "should match default encoding for BMP char %s",
     (_name, value, expected) => {
       expect(stringifyCookie({ key: value })).toEqual(expected);
     },
   );
 
-  it.each(defaultAstralEncodingCases)(
+  it.each(astralEncodingCases)(
     "should match default encoding for astral char %s",
     (_name, value, expected) => {
       expect(stringifyCookie({ key: value })).toEqual(expected);

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -38,22 +38,25 @@ describe("cookie.stringifyCookie", () => {
     );
     expect(stringifyCookie({ foo: "foo,bar" })).toEqual("foo=foo%2Cbar");
     expect(stringifyCookie({ foo: "foo\\bar" })).toEqual("foo=foo%5Cbar");
+    expect(stringifyCookie({ foo: "100%" })).toEqual("foo=100%25");
   });
 
-  it("should pass through cookie-octet values by default", () => {
+  it("should pass through roundtrip-safe cookie-octet values without encoding", () => {
     const value =
-      "!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+      "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
       "^_`abcdefghijklmnopqrstuvwxyz{|}~";
 
     expect(stringifyCookie({ foo: value })).toEqual(`foo=${value}`);
   });
 
-  it("should match cookie-octet default encoding", () => {
+  it("should match default encoding for all valid BMP characters", () => {
     const cookieOctets =
-      "!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+      "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
       "^_`abcdefghijklmnopqrstuvwxyz{|}~";
     const mismatches: string[] = [];
 
+    // Check every valid BMP character. Skip surrogate code units because
+    // encodeURIComponent throws on unpaired surrogates.
     for (let code = 0; code <= 0xffff; code++) {
       if (code >= 0xd800 && code <= 0xdfff) continue;
 
@@ -156,6 +159,14 @@ describe("cookie.stringifyCookie", () => {
     it("should roundtrip URL-encoded values", () => {
       const cookies = { session: "abc 123", token: "x=y&z" };
       const str = stringifyCookie(cookies);
+      expect(parseCookie(str)).toEqual(cookies);
+    });
+
+    it("should roundtrip percent-encoded-looking values", () => {
+      const cookies = { foo: "%20" };
+      const str = stringifyCookie(cookies);
+
+      expect(str).toEqual("foo=%2520");
       expect(parseCookie(str)).toEqual(cookies);
     });
 

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -23,15 +23,15 @@ for (let code = 0; code <= 0xffff; code++) {
   ]);
 }
 
-const astralEncodingCases: Array<[string, string, string]> = [];
-
-for (const value of ["😄", "𝌆", "𠜎"]) {
-  astralEncodingCases.push([
-    `U+${value.codePointAt(0)!.toString(16).toUpperCase()}`,
-    value,
-    `key=${encodeURIComponent(value)}`,
-  ]);
-}
+const astralEncodingCases: Array<[string, string, string]> = [
+  "😄",
+  "𝌆",
+  "𠜎",
+].map((value) => [
+  `U+${value.codePointAt(0)!.toString(16).toUpperCase()}`,
+  value,
+  `key=${encodeURIComponent(value)}`,
+]);
 
 describe("cookie.stringifyCookie", () => {
   it("should stringify object", () => {

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -36,6 +36,33 @@ describe("cookie.stringifyCookie", () => {
     );
   });
 
+  it("should match encodeURIComponent for default encoding", () => {
+    const mismatches: string[] = [];
+
+    for (let code = 0; code <= 0xffff; code++) {
+      if (code >= 0xd800 && code <= 0xdfff) continue;
+
+      const value = String.fromCharCode(code);
+      const actual = stringifyCookie({ key: value });
+      const expected = `key=${encodeURIComponent(value)}`;
+
+      if (actual !== expected) {
+        mismatches.push(`${code}: ${actual} !== ${expected}`);
+      }
+    }
+
+    for (const value of ["😄", "𝌆", "𠜎"]) {
+      const actual = stringifyCookie({ key: value });
+      const expected = `key=${encodeURIComponent(value)}`;
+
+      if (actual !== expected) {
+        mismatches.push(`${value}: ${actual} !== ${expected}`);
+      }
+    }
+
+    expect(mismatches).toEqual([]);
+  });
+
   it("should error on invalid keys", () => {
     expect(() => stringifyCookie({ "test=": "" })).toThrow(
       /cookie name is invalid/,

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -14,6 +14,7 @@ describe("cookie.stringifySetCookie", function () {
     expect(cookie.stringifySetCookie("foo", "bar +baz")).toEqual(
       "foo=bar%20%2Bbaz",
     );
+    expect(cookie.stringifySetCookie("foo", "100%")).toEqual("foo=100%25");
   });
 
   it("should pass through roundtrip-safe cookie-octet values without encoding", function () {

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -16,9 +16,9 @@ describe("cookie.stringifySetCookie", function () {
     );
   });
 
-  it("should pass through cookie-octet values", function () {
+  it("should pass through roundtrip-safe cookie-octet values without encoding", function () {
     const value =
-      "!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+      "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
       "^_`abcdefghijklmnopqrstuvwxyz{|}~";
 
     expect(cookie.stringifySetCookie("foo", value)).toEqual(`foo=${value}`);

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -10,10 +10,18 @@ describe("cookie.stringifySetCookie", function () {
     expect(cookie.stringifySetCookie("foo", "bar")).toEqual("foo=bar");
   });
 
-  it("should URL-encode value", function () {
+  it("should encode values with non-cookie-octet chars", function () {
     expect(cookie.stringifySetCookie("foo", "bar +baz")).toEqual(
       "foo=bar%20%2Bbaz",
     );
+  });
+
+  it("should pass through cookie-octet values", function () {
+    const value =
+      "!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+      "^_`abcdefghijklmnopqrstuvwxyz{|}~";
+
+    expect(cookie.stringifySetCookie("foo", value)).toEqual(`foo=${value}`);
   });
 
   it("should serialize empty value", function () {

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import * as cookie from "./index.js";
 
+const roundtripSafeCookieOctets =
+  "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
+  "^_`abcdefghijklmnopqrstuvwxyz{|}~";
+
 describe("cookie.stringifySetCookie", function () {
   it("should have backward compatible export", function () {
     expect(cookie.serialize).toBe(cookie.stringifySetCookie);
@@ -18,9 +22,7 @@ describe("cookie.stringifySetCookie", function () {
   });
 
   it("should pass through roundtrip-safe cookie-octet values without encoding", function () {
-    const value =
-      "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
-      "^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    const value = roundtripSafeCookieOctets;
 
     expect(cookie.stringifySetCookie("foo", value)).toEqual(`foo=${value}`);
   });

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import * as cookie from "./index.js";
 
-const roundtripSafeCookieOctets =
+const cookieOctets =
   "!#$&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]" +
   "^_`abcdefghijklmnopqrstuvwxyz{|}~";
 
@@ -22,7 +22,7 @@ describe("cookie.stringifySetCookie", function () {
   });
 
   it("should pass through roundtrip-safe cookie-octet values without encoding", function () {
-    const value = roundtripSafeCookieOctets;
+    const value = cookieOctets;
 
     expect(cookie.stringifySetCookie("foo", value)).toEqual(`foo=${value}`);
   });


### PR DESCRIPTION
# `stringifyCookie` Optimization

Optimizes default cookie encoding by skipping `encodeURIComponent` when values are already roundtrip-safe cookie-octets.

`%` is still encoded to preserve roundtrip behavior:

```ts
stringifyCookie({ foo: "%20" }) // foo=%2520
parseCookie("foo=%2520")        // { foo: "%20" }
```

## Benchmarks

> Higher `hz` is better. Measured on Node 24.15.0.

| case | before hz | after hz | speedup |
|---|---:|---:|---:|
| `empty` | 38,598,774.76 | 40,958,547.67 | 1.06x |
| `simple` | 11,020,607.14 | 16,615,825.47 | 1.51x |
| `rfc cookie-octets` | 7,463,520.33 | 15,267,614.96 | 2.05x |
| `encode` | 8,424,626.32 | 7,635,768.40 | 0.91x |
| `undefined values` | 5,783,315.75 | 8,068,459.56 | 1.40x |
| `mixed encode` | 3,977,455.71 | 4,320,201.87 | 1.09x |
| `10 cookies` | 1,297,376.60 | 1,895,381.87 | 1.46x |
| `100 cookies` | 130,578.34 | 179,100.23 | 1.37x |

## Summary

- `rfc cookie-octets`: **2.05x faster**
- `simple`: **1.51x faster**
- `10 cookies`: **1.46x faster**
- `100 cookies`: **1.37x faster**
- `encode` case: **0.91x**, slower because it checks the fast-path regexp before falling back to `encodeURIComponent`
