### PR TITLE
doc: Documents existing `parseCookie` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const cookieObject = cookie.parseCookie("foo=bar; equation=E%3Dmc%5E2");
 
 #### Options
 
-- `decode` Specifies the function to decode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`decodeURIComponent`](#encode-and-decode). Returning `undefined` will skip the value so a later duplicate can be used.
+- `decode` Specifies the function to decode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`decodeURIComponent`](#encode-and-decode).
 
 ### cookie.stringifyCookie(cookieObj, options)
 
@@ -182,8 +182,8 @@ The default `encode` function is the global `encodeURIComponent`.
 
 The default `decode` function is the global `decodeURIComponent`, wrapped in a `try..catch`. If an error
 is thrown it will return the cookie's original value. If you provide your own encode/decode
-scheme you must ensure errors are appropriately handled.
-Returning `undefined` from `decode` when parsing a `Cookie` header will skip the value so a later duplicate can be used.
+scheme you must ensure errors are appropriately handled. Custom decode functions can return `undefined`,
+which will skip the cookie during `parse` and try again with a future cookie of the same name.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const cookieObject = cookie.parseCookie("foo=bar; equation=E%3Dmc%5E2");
 
 #### Options
 
-- `decode` Specifies the function to decode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`decodeURIComponent`](#encode-and-decode).
+- `decode` Specifies the function to decode a [cookie-value](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1). Defaults to [`decodeURIComponent`](#encode-and-decode). Returning `undefined` will skip the value so a later duplicate can be used.
 
 ### cookie.stringifyCookie(cookieObj, options)
 
@@ -183,6 +183,7 @@ The default `encode` function is the global `encodeURIComponent`.
 The default `decode` function is the global `decodeURIComponent`, wrapped in a `try..catch`. If an error
 is thrown it will return the cookie's original value. If you provide your own encode/decode
 scheme you must ensure errors are appropriately handled.
+Returning `undefined` from `decode` when parsing a `Cookie` header will skip the value so a later duplicate can be used.
 
 ## Example
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export interface ParseOptions {
    * The default function is the global `decodeURIComponent`, wrapped in a `try..catch`. If an error
    * is thrown it will return the cookie's original value. If you provide your own encode/decode
    * scheme you must ensure errors are appropriately handled.
+   * Returning `undefined` will skip the value so a later duplicate can be used.
    *
    * @default decode
    */
@@ -111,8 +112,7 @@ export function parseCookie(str: string, options?: ParseOptions): Cookies {
   // RFC 6265 sec 4.1.1, RFC 2616 2.2 defines a cookie name consists of one char minimum, plus '='.
   if (len < 2) return obj;
 
-  const customDecode = options?.decode;
-  const dec = customDecode || decode;
+  const dec = options?.decode || decode;
   let index = 0;
 
   do {
@@ -130,10 +130,7 @@ export function parseCookie(str: string, options?: ParseOptions): Cookies {
     const key = valueSlice(str, index, eqIdx);
 
     // only assign once
-    if (
-      obj[key] === undefined &&
-      (customDecode === undefined || !(key in obj))
-    ) {
+    if (obj[key] === undefined) {
       obj[key] = dec(valueSlice(str, eqIdx + 1, endIdx));
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,8 +87,8 @@ export interface ParseOptions {
    *
    * The default function is the global `decodeURIComponent`, wrapped in a `try..catch`. If an error
    * is thrown it will return the cookie's original value. If you provide your own encode/decode
-   * scheme you must ensure errors are appropriately handled.
-   * Returning `undefined` will skip the value so a later duplicate can be used.
+   * scheme you must ensure errors are appropriately handled. Custom decode functions can return `undefined`,
+   * which will skip the cookie during `parse` and try again with a future cookie of the same name.
    *
    * @default decode
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,8 @@ export function parseCookie(str: string, options?: ParseOptions): Cookies {
   // RFC 6265 sec 4.1.1, RFC 2616 2.2 defines a cookie name consists of one char minimum, plus '='.
   if (len < 2) return obj;
 
-  const dec = options?.decode || decode;
+  const customDecode = options?.decode;
+  const dec = customDecode || decode;
   let index = 0;
 
   do {
@@ -129,7 +130,10 @@ export function parseCookie(str: string, options?: ParseOptions): Cookies {
     const key = valueSlice(str, index, eqIdx);
 
     // only assign once
-    if (obj[key] === undefined) {
+    if (
+      obj[key] === undefined &&
+      (customDecode === undefined || !(key in obj))
+    ) {
       obj[key] = dec(valueSlice(str, eqIdx + 1, endIdx));
     }
 

--- a/src/parse-cookie.spec.ts
+++ b/src/parse-cookie.spec.ts
@@ -110,5 +110,15 @@ describe("cookie.parseCookie", function () {
         }),
       ).toEqual({ foo: "bar" });
     });
+
+    it("should not overwrite undefined decoded duplicates", function () {
+      expect(
+        cookie.parseCookie("foo=bar; foo=baz", {
+          decode: function () {
+            return undefined;
+          },
+        }),
+      ).toEqual({ foo: undefined });
+    });
   });
 });

--- a/src/parse-cookie.spec.ts
+++ b/src/parse-cookie.spec.ts
@@ -112,13 +112,17 @@ describe("cookie.parseCookie", function () {
     });
 
     it("should not overwrite undefined decoded duplicates", function () {
+      let calls = 0;
+
       expect(
         cookie.parseCookie("foo=bar; foo=baz", {
           decode: function () {
-            return undefined;
+            return calls++ === 0 ? undefined : "baz";
           },
         }),
       ).toEqual({ foo: undefined });
+
+      expect(calls).toBe(1);
     });
   });
 });

--- a/src/parse-cookie.spec.ts
+++ b/src/parse-cookie.spec.ts
@@ -111,18 +111,19 @@ describe("cookie.parseCookie", function () {
       ).toEqual({ foo: "bar" });
     });
 
-    it("should not overwrite undefined decoded duplicates", function () {
+    it("should skip undefined decoded duplicates", function () {
       let calls = 0;
 
       expect(
         cookie.parseCookie("foo=bar; foo=baz", {
-          decode: function () {
-            return calls++ === 0 ? undefined : "baz";
+          decode: function (value) {
+            calls++;
+            return value === "bar" ? undefined : value;
           },
         }),
-      ).toEqual({ foo: undefined });
+      ).toEqual({ foo: "baz" });
 
-      expect(calls).toBe(1);
+      expect(calls).toBe(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

Documents existing `parseCookie` behavior when a custom `decode` returns `undefined`.

When `decode` returns `undefined`, `parseCookie` skips that value. If the same cookie name appears later, the later value can be used.
