### PR TITLE
Fix parse set cookie invalid attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -443,7 +443,7 @@ export function parseSetCookie(str: string, options?: ParseOptions): SetCookie {
         if (val !== undefined) setCookie.domain = val;
         break;
       case "path":
-        if (val !== undefined) setCookie.path = val;
+        setCookie.path = val;
         break;
       case "max-age":
         if (val && maxAgeRegExp.test(val)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,13 +440,16 @@ export function parseSetCookie(str: string, options?: ParseOptions): SetCookie {
         setCookie.partitioned = true;
         break;
       case "domain":
-        setCookie.domain = val;
+        if (val !== undefined) setCookie.domain = val;
         break;
       case "path":
-        setCookie.path = val;
+        if (val !== undefined) setCookie.path = val;
         break;
       case "max-age":
-        if (val && maxAgeRegExp.test(val)) setCookie.maxAge = Number(val);
+        if (val && maxAgeRegExp.test(val)) {
+          const maxAge = Number(val);
+          if (Number.isFinite(maxAge)) setCookie.maxAge = maxAge;
+        }
         break;
       case "expires":
         if (!val) break;

--- a/src/parse-set-cookie.spec.ts
+++ b/src/parse-set-cookie.spec.ts
@@ -164,6 +164,13 @@ describe("cookie.parseSetCookie", () => {
       });
     });
 
+    it("should ignore max-age when not finite", () => {
+      expect(parseSetCookie("key=value; Max-Age=" + "9".repeat(400))).toEqual({
+        name: "key",
+        value: "value",
+      });
+    });
+
     it("should parse negative max-age", () => {
       expect(parseSetCookie("key=value; Max-Age=-1")).toEqual({
         name: "key",
@@ -181,6 +188,13 @@ describe("cookie.parseSetCookie", () => {
         domain: "example.com",
       });
     });
+
+    it("should ignore domain with no value", () => {
+      expect(parseSetCookie("key=value; Domain")).toEqual({
+        name: "key",
+        value: "value",
+      });
+    });
   });
 
   describe('with "path"', () => {
@@ -189,6 +203,13 @@ describe("cookie.parseSetCookie", () => {
         name: "key",
         value: "value",
         path: "/some/path",
+      });
+    });
+
+    it("should ignore path with no value", () => {
+      expect(parseSetCookie("key=value; Path")).toEqual({
+        name: "key",
+        value: "value",
       });
     });
   });

--- a/src/parse-set-cookie.spec.ts
+++ b/src/parse-set-cookie.spec.ts
@@ -205,13 +205,6 @@ describe("cookie.parseSetCookie", () => {
         path: "/some/path",
       });
     });
-
-    it("should ignore path with no value", () => {
-      expect(parseSetCookie("key=value; Path")).toEqual({
-        name: "key",
-        value: "value",
-      });
-    });
   });
 
   describe('with "httpOnly"', () => {


### PR DESCRIPTION
## Summary

Avoid returning unusable values for malformed `Set-Cookie` attributes.

## Changes

- Ignore `Domain` when no value is provided.
- Avoid returning `maxAge: Infinity` when a digit-only `Max-Age` value overflows JavaScript's finite number range.

## Why

RFC 6265 says a `Set-Cookie` attribute without `=` has an empty attribute value:

https://datatracker.ietf.org/doc/html/rfc6265#section-5.2

For `Domain`, an empty value should be ignored entirely:

https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3

For `Max-Age`, digit-only values can still overflow in JavaScript:

```ts
Number("9".repeat(400)) === Infinity
```

This parser should not return `maxAge: Infinity`; it should treat non-finite parsed values as invalid and ignore the attribute.

## Tests

Added coverage for:

- `Max-Age` values that overflow to `Infinity`
- `Domain` without a value
