### PR TITLE
Switch to ESM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "18"
-          - "20"
           - "22"
+          - "latest"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "Douglas Christopher Wilson <doug@somethingdoug.com>"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": "./dist/index.js",
   "files": [
     "dist/"
   ],
@@ -42,7 +42,7 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "size-limit": [
     {


### PR DESCRIPTION
For the next major version will go ESM only, min node 22 (currently in maintenance).