### PR TITLE
Increment `=` index when parsing `set-cookie`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "1.2 KB"
+      "limit": "1.4 KB"
     }
   ],
   "ts-scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "1.4 KB"
+      "limit": "1.2 KB"
     }
   ],
   "ts-scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -400,12 +400,12 @@ export function parseSetCookie(str: string, options?: ParseOptions): SetCookie {
   const endIdx = endIndex(str, 0, len);
   let eqIdx = eqIndex(str, 0, len);
   const setCookie: SetCookie =
-    eqIdx >= endIdx
-      ? { name: "", value: dec(valueSlice(str, 0, endIdx)) }
-      : {
+    eqIdx < endIdx
+      ? {
           name: valueSlice(str, 0, eqIdx),
           value: dec(valueSlice(str, eqIdx + 1, endIdx)),
-        };
+        }
+      : { name: "", value: dec(valueSlice(str, 0, endIdx)) };
 
   let index = endIdx + 1;
   while (index < len) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export function parseCookie(str: string, options?: ParseOptions): Cookies {
 
   do {
     const eqIdx = eqIndex(str, index, len);
-    if (eqIdx === -1) break; // No more cookie pairs.
+    if (eqIdx === len) break; // No more cookie pairs.
 
     const endIdx = endIndex(str, index, len);
 
@@ -398,9 +398,9 @@ export function parseSetCookie(str: string, options?: ParseOptions): SetCookie {
   const dec = options?.decode || decode;
   const len = str.length;
   const endIdx = endIndex(str, 0, len);
-  const eqIdx = eqIndex(str, 0, endIdx);
+  let eqIdx = eqIndex(str, 0, len);
   const setCookie: SetCookie =
-    eqIdx === -1
+    eqIdx >= endIdx
       ? { name: "", value: dec(valueSlice(str, 0, endIdx)) }
       : {
           name: valueSlice(str, 0, eqIdx),
@@ -410,12 +410,13 @@ export function parseSetCookie(str: string, options?: ParseOptions): SetCookie {
   let index = endIdx + 1;
   while (index < len) {
     const endIdx = endIndex(str, index, len);
-    const eqIdx = eqIndex(str, index, endIdx);
+    if (eqIdx < index) eqIdx = eqIndex(str, index, len);
+
     const attr =
-      eqIdx === -1
-        ? valueSlice(str, index, endIdx)
-        : valueSlice(str, index, eqIdx);
-    const val = eqIdx === -1 ? undefined : valueSlice(str, eqIdx + 1, endIdx);
+      eqIdx < endIdx
+        ? valueSlice(str, index, eqIdx)
+        : valueSlice(str, index, endIdx);
+    const val = eqIdx < endIdx ? valueSlice(str, eqIdx + 1, endIdx) : undefined;
 
     switch (attr.toLowerCase()) {
       case "httponly":
@@ -472,7 +473,7 @@ export function parseSetCookie(str: string, options?: ParseOptions): SetCookie {
 }
 
 /**
- * Find the `;` character between `min` and `len` in str.
+ * Find the next `;` character, or return `len`.
  */
 function endIndex(str: string, min: number, len: number) {
   const index = str.indexOf(";", min);
@@ -480,11 +481,11 @@ function endIndex(str: string, min: number, len: number) {
 }
 
 /**
- * Find the `=` character between `min` and `max` in str.
+ * Find the next `=` character, or return `len`.
  */
-function eqIndex(str: string, min: number, max: number) {
+function eqIndex(str: string, min: number, len: number) {
   const index = str.indexOf("=", min);
-  return index < max ? index : -1;
+  return index === -1 ? len : index;
 }
 
 /**

--- a/src/parse-cookie.bench.ts
+++ b/src/parse-cookie.bench.ts
@@ -33,6 +33,11 @@ describe("cookie.parseCookie", () => {
   bench("100 cookies", () => {
     cookie.parseCookie(cookies100);
   });
+
+  const semicolons = ";".repeat(100_000);
+  bench("100k semicolons", () => {
+    cookie.parseCookie(semicolons);
+  });
 });
 
 describe("parse top-sites", () => {

--- a/src/parse-set-cookie.bench.ts
+++ b/src/parse-set-cookie.bench.ts
@@ -10,4 +10,9 @@ describe("parse top-sites", () => {
       }
     });
   });
+
+  const semicolons = "a;".repeat(100_000);
+  bench("100k semicolons", () => {
+    cookie.parseSetCookie(semicolons);
+  });
 });

--- a/src/parse-set-cookie.bench.ts
+++ b/src/parse-set-cookie.bench.ts
@@ -11,7 +11,7 @@ describe("parse top-sites", () => {
     });
   });
 
-  const semicolons = "a;".repeat(100_000);
+  const semicolons = ";".repeat(100_000);
   bench("100k semicolons", () => {
     cookie.parseSetCookie(semicolons);
   });


### PR DESCRIPTION
Better performance when parsing `set-cookie` with many parameters and no `=` within them.

Before:

```
 ✓ src/parse-set-cookie.bench.ts > parse top-sites 17277ms
     name                                 hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parse apple.com            5,786,691.21  0.0000  2.6515  0.0002  0.0002  0.0002  0.0003  0.0012  ±1.25%  2893346
   · parse cloudflare.com         348,297.33  0.0026  0.2212  0.0029  0.0029  0.0034  0.0037  0.0211  ±0.36%   174149
   · parse docs.google.com      1,893,491.25  0.0004  3.9001  0.0005  0.0005  0.0006  0.0007  0.0026  ±1.74%   946746
   · parse en.wikipedia.org       375,289.58  0.0024  4.9893  0.0027  0.0026  0.0033  0.0071  0.0262  ±1.98%   187645
   · parse linkedin.com         1,697,462.88  0.0005  0.2036  0.0006  0.0006  0.0007  0.0007  0.0012  ±0.33%   848732
   · parse microsoft.com          906,743.03  0.0010  0.2070  0.0011  0.0011  0.0012  0.0013  0.0037  ±0.31%   453372
   · parse play.google.com      2,042,916.78  0.0004  2.2218  0.0005  0.0005  0.0006  0.0006  0.0010  ±0.91%  1021459
   · parse policies.google.com  2,065,324.01  0.0004  0.1789  0.0005  0.0005  0.0005  0.0006  0.0010  ±0.30%  1032663
   · parse support.google.com   1,027,358.12  0.0008  0.1546  0.0010  0.0010  0.0011  0.0012  0.0016  ±0.26%   513680
   · parse t.me                 1,657,462.31  0.0004  3.9306  0.0006  0.0005  0.0008  0.0015  0.0112  ±1.74%   828732
   · parse tiktok.com             572,158.71  0.0016  1.8228  0.0017  0.0018  0.0020  0.0022  0.0040  ±0.75%   286080
   · parse wa.me                1,607,501.22  0.0005  1.5157  0.0006  0.0006  0.0007  0.0008  0.0011  ±0.88%   803751
   · parse whatsapp.com           576,792.30  0.0015  0.1886  0.0017  0.0017  0.0019  0.0021  0.0257  ±0.29%   288397
   · parse www.google.com         590,383.50  0.0015  0.2378  0.0017  0.0017  0.0019  0.0020  0.0260  ±0.31%   295192
   · parse x.com                  223,105.43  0.0041  0.4303  0.0045  0.0044  0.0061  0.0085  0.0304  ±0.36%   111553
   · parse youtu.be               228,680.16  0.0041  0.2073  0.0044  0.0043  0.0047  0.0049  0.0292  ±0.29%   114341
   · parse youtube.com            230,847.11  0.0041  0.1640  0.0043  0.0043  0.0048  0.0049  0.0090  ±0.23%   115424
   · 100k semicolons                  4.3820  224.23  232.05  228.21  230.91  232.05  232.05  232.05  ±0.82%       10
```

After:

```
 ✓ src/parse-set-cookie.bench.ts > parse top-sites 14013ms
     name                                 hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parse apple.com            5,795,959.87  0.0000  6.7030  0.0002  0.0002  0.0002  0.0003  0.0010  ±2.74%  2897980
   · parse cloudflare.com         361,453.47  0.0025  0.2203  0.0028  0.0027  0.0032  0.0035  0.0152  ±0.33%   180727
   · parse docs.google.com      2,017,995.73  0.0004  3.4419  0.0005  0.0005  0.0006  0.0006  0.0010  ±1.37%  1008998
   · parse en.wikipedia.org       396,007.30  0.0023  1.6713  0.0025  0.0025  0.0029  0.0033  0.0107  ±0.71%   198004
   · parse linkedin.com         1,723,331.17  0.0005  0.1601  0.0006  0.0006  0.0007  0.0008  0.0029  ±0.27%   861666
   · parse microsoft.com          898,687.05  0.0009  3.7118  0.0011  0.0011  0.0013  0.0015  0.0083  ±1.48%   449344
   · parse play.google.com      2,056,782.97  0.0004  0.2088  0.0005  0.0005  0.0006  0.0006  0.0045  ±0.28%  1028392
   · parse policies.google.com  2,063,004.28  0.0004  0.1874  0.0005  0.0005  0.0006  0.0006  0.0010  ±0.29%  1031503
   · parse support.google.com   1,017,708.76  0.0008  0.1855  0.0010  0.0010  0.0011  0.0012  0.0031  ±0.31%   508855
   · parse t.me                 1,908,612.99  0.0004  0.1916  0.0005  0.0005  0.0006  0.0007  0.0010  ±0.32%   954307
   · parse tiktok.com             563,532.72  0.0015  7.9198  0.0018  0.0017  0.0022  0.0032  0.0258  ±3.48%   281767
   · parse wa.me                1,629,260.49  0.0005  0.1502  0.0006  0.0006  0.0007  0.0007  0.0012  ±0.30%   814631
   · parse whatsapp.com           589,975.03  0.0015  0.1756  0.0017  0.0017  0.0018  0.0020  0.0261  ±0.31%   294988
   · parse www.google.com         573,624.39  0.0015  5.6973  0.0017  0.0017  0.0021  0.0025  0.0262  ±2.25%   286813
   · parse x.com                  222,605.55  0.0041  3.7246  0.0045  0.0042  0.0064  0.0127  0.0335  ±1.49%   111303
   · parse youtu.be               231,565.26  0.0040  0.1785  0.0043  0.0043  0.0048  0.0051  0.0335  ±0.30%   115783
   · parse youtube.com            234,840.62  0.0040  0.2076  0.0043  0.0042  0.0046  0.0048  0.0336  ±0.31%   117421
   · 100k semicolons                  394.69  2.4592  2.7219  2.5336  2.5539  2.7155  2.7219  2.7219  ±0.30%      198
```

No real change except for the unrealistic semicolon only edge case added.