### PR TITLE
chore: do not include sourcemap in dist

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "inlineSources": false
+  },
   "exclude": ["src/**/*.spec.ts", "src/**/*.bench.ts"]
 }


### PR DESCRIPTION
`cookie` is [pretty big compared to alternatives](https://npmx.dev/compare?packages=cookie,cookie-es,js-cookie,es-cookie&facets=installSize,totalDependencies,downloads,lastUpdated,githubStars,engines,types,moduleFormat), and part of it is due shipping a sourcemap. This is not necessary so it removes it (size: from 60.8 kB to 34kB). This should likely be a patch release.

Made as part of the [e18e](https://e18e.dev/) intiative.