### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
   ],
   "ts-scripts": {
     "project": "tsconfig.build.json"
+  },
+  "homepage": "https://github.com/jshttp/cookie",
+  "bugs": {
+    "url": "https://github.com/jshttp/cookie/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.