### PR TITLE
Small convention cleanups

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export function parseCookie(str: string, options?: ParseOptions): Cookies {
   // RFC 6265 sec 4.1.1, RFC 2616 2.2 defines a cookie name consists of one char minimum, plus '='.
   if (len < 2) return obj;
 
-  const dec = options?.decode || decode;
+  const dec = options?.decode ?? defaultDecode;
   let index = 0;
 
   do {
@@ -160,7 +160,7 @@ export function stringifyCookie(
   cookie: Cookies,
   options?: StringifyOptions,
 ): string {
-  const enc = options?.encode || defaultEncode;
+  const enc = options?.encode ?? defaultEncode;
   const keys = Object.keys(cookie);
   let str = "";
 
@@ -286,23 +286,23 @@ export function stringifySetCookie(
   cookie: SetCookie,
   options?: StringifyOptions,
 ): string {
-  const enc = options?.encode || defaultEncode;
+  const enc = options?.encode ?? defaultEncode;
 
   if (!cookieNameRegExp.test(cookie.name)) {
-    throw new TypeError(`argument name is invalid: ${cookie.name}`);
+    throw new TypeError(`cookie name is invalid: ${cookie.name}`);
   }
 
   const value = cookie.value == null ? "" : enc(cookie.value);
 
   if (!cookieValueRegExp.test(value)) {
-    throw new TypeError(`argument val is invalid: ${cookie.value}`);
+    throw new TypeError(`cookie value is invalid: ${cookie.value}`);
   }
 
   let str = cookie.name + "=" + value;
 
   if (cookie.maxAge !== undefined) {
     if (!Number.isInteger(cookie.maxAge)) {
-      throw new TypeError(`option maxAge is invalid: ${cookie.maxAge}`);
+      throw new TypeError(`cookie maxAge is invalid: ${cookie.maxAge}`);
     }
 
     str += "; Max-Age=" + cookie.maxAge;
@@ -310,7 +310,7 @@ export function stringifySetCookie(
 
   if (cookie.domain) {
     if (!domainValueRegExp.test(cookie.domain)) {
-      throw new TypeError(`option domain is invalid: ${cookie.domain}`);
+      throw new TypeError(`cookie domain is invalid: ${cookie.domain}`);
     }
 
     str += "; Domain=" + cookie.domain;
@@ -318,7 +318,7 @@ export function stringifySetCookie(
 
   if (cookie.path) {
     if (!pathValueRegExp.test(cookie.path)) {
-      throw new TypeError(`option path is invalid: ${cookie.path}`);
+      throw new TypeError(`cookie path is invalid: ${cookie.path}`);
     }
 
     str += "; Path=" + cookie.path;
@@ -326,7 +326,7 @@ export function stringifySetCookie(
 
   if (cookie.expires) {
     if (!Number.isFinite(cookie.expires.valueOf())) {
-      throw new TypeError(`option expires is invalid: ${cookie.expires}`);
+      throw new TypeError(`cookie expires is invalid: ${cookie.expires}`);
     }
 
     str += "; Expires=" + cookie.expires.toUTCString();
@@ -360,7 +360,7 @@ export function stringifySetCookie(
         str += "; Priority=High";
         break;
       default:
-        throw new TypeError(`option priority is invalid: ${cookie.priority}`);
+        throw new TypeError(`cookie priority is invalid: ${cookie.priority}`);
     }
   }
 
@@ -381,7 +381,7 @@ export function stringifySetCookie(
         str += "; SameSite=None";
         break;
       default:
-        throw new TypeError(`option sameSite is invalid: ${cookie.sameSite}`);
+        throw new TypeError(`cookie sameSite is invalid: ${cookie.sameSite}`);
     }
   }
 
@@ -395,7 +395,7 @@ export function stringifySetCookie(
  *   => { name: 'foo', value: 'bar', httpOnly: true }
  */
 export function parseSetCookie(str: string, options?: ParseOptions): SetCookie {
-  const dec = options?.decode || decode;
+  const dec = options?.decode ?? defaultDecode;
   const len = str.length;
   const endIdx = endIndex(str, 0, len);
   let eqIdx = eqIndex(str, 0, len);
@@ -513,7 +513,7 @@ function valueSlice(str: string, min: number, max: number) {
 /**
  * URL-decode string value. Optimized to skip native call when no %.
  */
-function decode(str: string): string {
+function defaultDecode(str: string): string {
   if (str.indexOf("%") === -1) return str;
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export function stringifyCookie(
     const value = enc(val);
 
     if (!cookieValueRegExp.test(value)) {
-      throw new TypeError(`cookie val is invalid: ${val}`);
+      throw new TypeError(`cookie value is invalid: ${val}`);
     }
 
     if (str) str += "; ";

--- a/src/stringify-cookie.spec.ts
+++ b/src/stringify-cookie.spec.ts
@@ -110,7 +110,7 @@ describe("cookie.stringifyCookie", () => {
 
   it("should error on invalid values", () => {
     expect(() => stringifyCookie({ test: ";" }, { encode: (x) => x })).toThrow(
-      /cookie val is invalid/,
+      /cookie value is invalid/,
     );
   });
 
@@ -154,7 +154,7 @@ describe("cookie.stringifyCookie", () => {
     it("should throw when custom encoder produces invalid value", () => {
       expect(() =>
         stringifyCookie({ foo: "bar" }, { encode: () => "invalid value" }),
-      ).toThrow(/cookie val is invalid/);
+      ).toThrow(/cookie value is invalid/);
     });
   });
 

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -82,7 +82,7 @@ describe("cookie.stringifySetCookie", () => {
     ["foo\tbar"],
   ])("should throw for invalid name: %s", (name) => {
     expect(() => stringifySetCookie({ name, value: "bar" })).toThrow(
-      /argument name is invalid/,
+      /cookie name is invalid/,
     );
   });
 
@@ -110,7 +110,7 @@ describe("cookie.stringifySetCookie", () => {
     ])("should throw for invalid domain: %s", (domain) => {
       expect(() =>
         stringifySetCookie({ name: "foo", value: "bar", domain }),
-      ).toThrow(/option domain is invalid/);
+      ).toThrow(/cookie domain is invalid/);
     });
   });
 
@@ -149,7 +149,7 @@ describe("cookie.stringifySetCookie", () => {
       (value) => {
         expect(() =>
           stringifySetCookie({ name: "foo", value }, { encode: (x) => x }),
-        ).toThrow(/argument val is invalid/);
+        ).toThrow(/cookie value is invalid/);
       },
     );
   });
@@ -162,7 +162,7 @@ describe("cookie.stringifySetCookie", () => {
           value: "bar",
           expires: new Date(NaN),
         }),
-      ).toThrow(/option expires is invalid/);
+      ).toThrow(/cookie expires is invalid/);
     });
 
     it("should set expires to given date", () => {
@@ -184,7 +184,7 @@ describe("cookie.stringifySetCookie", () => {
     ])("should throw when maxAge is %s", (_label, maxAge) => {
       expect(() =>
         stringifySetCookie({ name: "foo", value: "bar", maxAge } as any),
-      ).toThrow(/option maxAge is invalid/);
+      ).toThrow(/cookie maxAge is invalid/);
     });
 
     it("should set max-age to value", () => {
@@ -223,7 +223,7 @@ describe("cookie.stringifySetCookie", () => {
     ])("should throw for invalid path: %s", (path) => {
       expect(() =>
         stringifySetCookie({ name: "foo", value: "bar", path }),
-      ).toThrow(/option path is invalid/);
+      ).toThrow(/cookie path is invalid/);
     });
   });
 
@@ -260,7 +260,7 @@ describe("cookie.stringifySetCookie", () => {
     ])("should throw on %s", (_label, priority) => {
       expect(() =>
         stringifySetCookie({ name: "foo", value: "bar", priority } as any),
-      ).toThrow(/option priority is invalid/);
+      ).toThrow(/cookie priority is invalid/);
     });
 
     it.each([
@@ -287,7 +287,7 @@ describe("cookie.stringifySetCookie", () => {
           value: "bar",
           sameSite: "foo" as any,
         }),
-      ).toThrow(/option sameSite is invalid/);
+      ).toThrow(/cookie sameSite is invalid/);
     });
 
     it.each([


### PR DESCRIPTION
Use `??` for default function, rename `decode` to `defaultDecode`, update cookie error messages to prefix `cookie` instead of option/arg.