### PR TITLE
fix: reject unsafe-integer maxAge in stringifySetCookie

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,7 +301,7 @@ export function stringifySetCookie(
   let str = cookie.name + "=" + value;
 
   if (cookie.maxAge !== undefined) {
-    if (!Number.isInteger(cookie.maxAge)) {
+    if (!Number.isSafeInteger(cookie.maxAge)) {
       throw new TypeError(`option maxAge is invalid: ${cookie.maxAge}`);
     }
 

--- a/src/stringify-set-cookie.spec.ts
+++ b/src/stringify-set-cookie.spec.ts
@@ -181,6 +181,7 @@ describe("cookie.stringifySetCookie", () => {
       ["non-number", "buzz"],
       ["Infinity", Infinity],
       ["non-integer", 3.14],
+      ["unsafe integer", 1e21],
     ])("should throw when maxAge is %s", (_label, maxAge) => {
       expect(() =>
         stringifySetCookie({ name: "foo", value: "bar", maxAge } as any),


### PR DESCRIPTION
`stringifySetCookie` guards `maxAge` with `Number.isInteger`, but that accepts integers `>= 1e21`, which `String()` renders in exponential notation. The result is a `Max-Age` that breaks the RFC 6265 §5.2.2 grammar (`max-age-value = 1*DIGIT`):

```js
stringifySetCookie({ name: "foo", value: "bar", maxAge: 1e21 })
// => "foo=bar; Max-Age=1e+21"   (invalid; no compliant parser accepts it)
```

The guard exists precisely to guarantee a valid header (it already rejects `Infinity`/`NaN`/non-integers), so letting these values through defeats its purpose. It also corrupts a parse -> serialize round-trip: `Max-Age=<22 digits>` is a valid header a server may send, `parseSetCookie` reads it as `1e21`, and re-serializing yields the broken output above.

Switching to `Number.isSafeInteger` keeps the emitted value a plain integer (safe integers are `<= 2^53`, well below the exponential threshold) and still accepts every realistic Max-Age. All existing cases (`0`, `-1`, `1000`, and the `Infinity`/`3.14`/non-number throw cases) are unaffected.

Adds a regression test.
